### PR TITLE
Left-align footer copy labels in FIFO reports

### DIFF
--- a/src/mainTopics/fifo/PHVDamageFIFO.tsx
+++ b/src/mainTopics/fifo/PHVDamageFIFO.tsx
@@ -789,7 +789,7 @@ const PHVDamageFIFO: React.FC = () => {
                       <span className="font-bold">Date of Verification :</span> {verificationDate}
                     </div>
                   </div>
-                  <div className="text-right">
+                  <div className="text-left">
                     <div>1.ORIGINAL : Deputy General Manager</div>
                     <div>2.DUPLICATE : Engineer-in-charge</div>
                     <div>3.TRIPLICATE : Store-keeper/E.S.(C.S.C)</div>

--- a/src/mainTopics/fifo/PHVNonMovingWHReport.tsx
+++ b/src/mainTopics/fifo/PHVNonMovingWHReport.tsx
@@ -792,7 +792,7 @@ const PHVNonMovingWHReport: React.FC = () => {
                       <span className="font-bold">Date of Verification :</span> {verificationDate}
                     </div>
                   </div>
-                  <div className="text-right">
+                  <div className="text-left">
                     <div>1.ORIGINAL : Deputy General Manager</div>
                     <div>2.DUPLICATE : Engineer-in-charge</div>
                     <div>3.TRIPLICATE : Store-keeper/E.S.(C.S.C)</div>

--- a/src/mainTopics/fifo/PHVObsoleteIdleFIFO.tsx
+++ b/src/mainTopics/fifo/PHVObsoleteIdleFIFO.tsx
@@ -787,7 +787,7 @@ const PHVObsoleteIdleFIFO: React.FC = () => {
                       <span className="font-bold">Date of Verification :</span> {verificationDate}
                     </div>
                   </div>
-                  <div className="text-right">
+                  <div className="text-left">
                     <div>1.ORIGINAL : Deputy General Manager</div>
                     <div>2.DUPLICATE : Engineer-in-charge</div>
                     <div>3.TRIPLICATE : Store-keeper/E.S.(C.S.C)</div>

--- a/src/mainTopics/fifo/PHVSlowMovingWHReport.tsx
+++ b/src/mainTopics/fifo/PHVSlowMovingWHReport.tsx
@@ -796,7 +796,7 @@ const PHVSlowMovingWHReport: React.FC = () => {
                       <span className="font-bold">Date of Verification :</span> {verificationDate}
                     </div>
                   </div>
-                  <div className="text-right">
+                  <div className="text-left">
                     <div>1.ORIGINAL : Deputy General Manager</div>
                     <div>2.DUPLICATE : Engineer-in-charge</div>
                     <div>3.TRIPLICATE : Store-keeper/E.S.(C.S.C)</div>


### PR DESCRIPTION
Change alignment of the recipient/copy labels from 'text-right' to 'text-left' in four FIFO PHV report components for consistent layout and improved readability. Files updated: src/mainTopics/fifo/PHVDamageFIFO.tsx, src/mainTopics/fifo/PHVNonMovingWHReport.tsx, src/mainTopics/fifo/PHVObsoleteIdleFIFO.tsx, src/mainTopics/fifo/PHVSlowMovingWHReport.tsx.