### PR TITLE
Fix: FIFO report shown to users without Physical Verification permission

### DIFF
--- a/src/components/layout/AdminNavBar.tsx
+++ b/src/components/layout/AdminNavBar.tsx
@@ -69,7 +69,7 @@ const AdminNavBar = () => {
               REPORTING System
             </div>
             <div className="text-[11px] px-2 py-0.5 rounded-full bg-white/20 text-white">
-              v1.2
+              v1.5
             </div>
           </div>
         </Link>
@@ -143,7 +143,7 @@ const AdminNavBar = () => {
 
             <div className="p-3 bg-gray-50 border-t border-gray-100">
               <div className="text-xs text-gray-500 text-center">
-                Reporting System Portal v1.2
+                Reporting System Portal v1.5
               </div>
             </div>
           </div>

--- a/src/data/SideBarData.ts
+++ b/src/data/SideBarData.ts
@@ -472,24 +472,24 @@ export const loadRoleBasedSidebarData = async (epfNo: string): Promise<SidebarRe
 
     const reports = Array.from(reportsByKey.values());
 
-    // Inject the FIFO report under Physical Verification (as an accordion item) and under FIFO category
-    const hasFifoReport = reports.some(
-      (r) =>
-        getReportRepId(r) === "fifo-obsolete-idle" ||
-        getReportName(r).toLowerCase().includes("fifo")
-    );
-    if (!hasFifoReport) {
-      reports.push({
-        RepIdNo: "fifo-obsolete-idle",
-        CategoryName: "Physical Verification",
-        ReportName: "PHV Obsolete / Idle (FIFO)",
-      });
-      reports.push({
-        RepIdNo: "fifo-obsolete-idle-cat",
-        CategoryName: "Physical Verification - FIFO",
-        ReportName: "PHV Obsolete / Idle (FIFO)",
-      });
-    }
+    // // Inject the FIFO report under Physical Verification (as an accordion item) and under FIFO category
+    // const hasFifoReport = reports.some(
+    //   (r) =>
+    //     getReportRepId(r) === "fifo-obsolete-idle" ||
+    //     getReportName(r).toLowerCase().includes("fifo")
+    // );
+    // if (!hasFifoReport) {
+    //   reports.push({
+    //     RepIdNo: "fifo-obsolete-idle",
+    //     CategoryName: "Physical Verification",
+    //     ReportName: "PHV Obsolete / Idle (FIFO)",
+    //   });
+    //   reports.push({
+    //     RepIdNo: "fifo-obsolete-idle-cat",
+    //     CategoryName: "Physical Verification - FIFO",
+    //     ReportName: "PHV Obsolete / Idle (FIFO)",
+    //   });
+    // }
 
     const topics = buildTopics(reports);
 

--- a/src/mainTopics/inventory/Ccwiseissue.tsx
+++ b/src/mainTopics/inventory/Ccwiseissue.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Download, Printer, X, RotateCcw, Eye, Search } from "lucide-react";
 import { toast } from "react-toastify";
 import { useUser } from "../../contexts/UserContext";
@@ -88,7 +88,7 @@ const CCWiseIssue: React.FC = () => {
 	const [reportData, setReportData] = useState<CCWiseIssueRow[]>([]);
 	const [reportLoading, setReportLoading] = useState(false);
 	const [showReport, setShowReport] = useState(false);
-	const [reportError, setReportError] = useState<string | null>(null);
+	const [, setReportError] = useState<string | null>(null);
 
 	/* ────── Fetch Departments ────── */
 	useEffect(() => {


### PR DESCRIPTION
## Problem
Users without "Physical Verification" or "Physical Verification - FIFO" role permissions were still seeing both categories in their sidebar, with a "PHV Obsolete / Idle (FIFO)" report under each. DB role data was correct — the issue was frontend-only.

## Root cause
`loadRoleBasedSidebarData()` in `SideBarData.ts` had a block that checked if a user's fetched reports included anything with "fifo" in the name, and if not, pushed two hardcoded fake report entries (one per category) into the list before building sidebar topics —
with no permission check at all.

## Fix
Removed the hardcoded injection block. Sidebar categories/reports now strictly reflect what the backend returns for the user's role.

## Testing
- Verified `fifo-obsolete-idle` / `fifo-obsolete-idle-cat` repIdNo values aren't referenced anywhere else in the codebase.
- Confirmed `reportComponentRegistry.ts` resolves the FIFO report component by matching the report name string, not this hardcoded RepIdNo — so users who legitimately have this report via the DB still get it rendered correctly.
- Logged in as PUCSL/LISS-only test user — Physical Verification categories no longer appear.