### PR TITLE
Add level-based (Chairman/Region/Province/Area) access control to Solar Information reports

### DIFF
--- a/src/components/login/LoginCard.tsx
+++ b/src/components/login/LoginCard.tsx
@@ -47,7 +47,7 @@ const LoginCard = () => {
               body: JSON.stringify({ ad_user_name: username, ad_password: password }),
             }
           );
-          
+
           if (response.ok) {
             let adRes: any = null;
             try {
@@ -94,7 +94,7 @@ const LoginCard = () => {
             const adminCheck = await fetch("/misapi/api/roleinfo/admin");
             if (adminCheck.ok) {
               const adminPayload = await adminCheck.json();
-              const isAdminInDb = Array.isArray(adminPayload?.data) && adminPayload.data.some((a: any) => 
+              const isAdminInDb = Array.isArray(adminPayload?.data) && adminPayload.data.some((a: any) =>
                 String(a?.EpfNo).trim() === String(username).trim()
               );
               if (!isAdminInDb) {
@@ -108,10 +108,10 @@ const LoginCard = () => {
               return;
             }
           } catch (err) {
-             console.error("Admin verification error:", err);
-             toast.error("Error verifying admin status.");
-             setLogged({ Logged: false, Errormsg: "" });
-             return;
+            console.error("Admin verification error:", err);
+            toast.error("Error verifying admin status.");
+            setLogged({ Logged: false, Errormsg: "" });
+            return;
           }
         }
 
@@ -127,9 +127,38 @@ const LoginCard = () => {
           Password: password,
         });
 
-        // Add admin flag if checked
         if (userData && isAdmin) {
-             userData.isAdmin = true;
+          userData.isAdmin = true;
+        }
+
+        // Fetch access-level info (Level + BillMap code) from the real BillMap API
+        try {
+          const billMapRes = await fetch(`/misapi/api/billmap/${username.trim()}`);
+          const billMapData = await billMapRes.json();
+          const entry = Array.isArray(billMapData) ? billMapData[0] : null;
+
+          if (entry) {
+            const level = parseInt(entry.LevelNo, 10) || 0;
+            const code = (entry.BillMap || "").trim();
+            const name = (entry.CompanyName || "").trim();
+
+            userData.Level = level;
+
+            if (level >= 80) {
+              // Chairman / top level — no lock needed, sees everything
+            } else if (level >= 70) {
+              userData.RegionCode = code;
+              userData.RegionName = name;
+            } else if (level >= 60) {
+              userData.ProvinceCode = code;
+              userData.ProvinceName = name;
+            } else {
+              userData.AreaCode = code;
+              userData.AreaName = name;
+            }
+          }
+        } catch (err) {
+          console.error("Could not load BillMap access profile:", err);
         }
 
         setUser(userData);
@@ -158,7 +187,7 @@ const LoginCard = () => {
             className="w-24 sm:w-32 md:w-35 h-auto"
           />
         </div>
-        
+
         <div className="text-center text-sm sm:text-base text-gray-600 mb-4 sm:mb-6">
           Sign In With Credentials
         </div>
@@ -198,11 +227,10 @@ const LoginCard = () => {
           <div className="mt-2 flex w-full flex-col gap-3 sm:flex-row">
             <button
               type="button"
-              className={`w-full rounded-md px-4 py-2.5 text-sm font-semibold sm:text-base shadow-sm transition-all duration-150 ${
-                loginType === "HR"
-                  ? "bg-[#7c0000] text-white hover:bg-[#690000]"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-              }`}
+              className={`w-full rounded-md px-4 py-2.5 text-sm font-semibold sm:text-base shadow-sm transition-all duration-150 ${loginType === "HR"
+                ? "bg-[#7c0000] text-white hover:bg-[#690000]"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
               onClick={(e) => {
                 setLoginType("HR");
                 handleSubmit(e, "HR");
@@ -212,11 +240,10 @@ const LoginCard = () => {
             </button>
             <button
               type="button"
-              className={`w-full rounded-md px-4 py-2.5 text-sm font-semibold sm:text-base shadow-sm transition-all duration-150 ${
-                loginType === "AD"
-                  ? "bg-[#7c0000] text-white hover:bg-[#690000]"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-              }`}
+              className={`w-full rounded-md px-4 py-2.5 text-sm font-semibold sm:text-base shadow-sm transition-all duration-150 ${loginType === "AD"
+                ? "bg-[#7c0000] text-white hover:bg-[#690000]"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
               onClick={(e) => {
                 setLoginType("AD");
                 handleSubmit(e, "AD");

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -20,6 +20,12 @@ type User = {
   Common_exception: string | null;
   Errormsg: string | null;
   Logged: boolean;
+  Level?: number;
+  AreaCode?: string;
+  AreaName?: string;
+  ProvinceCode?: string;
+  ProvinceName?: string;
+  RegionCode?: string;
 };
 
 type UserContextType = {
@@ -48,6 +54,13 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
           Common_exception: "",
           Errormsg: "",
           Logged: false,
+          Level: 0,
+          AreaCode: "",
+          AreaName: "",
+          ProvinceCode: "",
+          ProvinceName: "",
+          RegionCode: "",
+          RegionName: "",
         };
   });
 

--- a/src/hooks/useReportRenderer.tsx
+++ b/src/hooks/useReportRenderer.tsx
@@ -5,8 +5,8 @@ import {
 } from "../utils/reportComponentRegistry";
 import { normalizeReportName } from "../utils/reportNameMatch";
 import DynamicReportByRepId from "../components/shared/DynamicReportByRepId";
-import CcApplicationProgress from "../mainTopics/SolarJobs/CcApplicationProgress";
-import PHVObsoleteIdleFIFO from "../mainTopics/fifo/PHVObsoleteIdleFIFO";
+// import CcApplicationProgress from "../mainTopics/SolarJobs/CcApplicationProgress";
+// import PHVObsoleteIdleFIFO from "../mainTopics/fifo/PHVObsoleteIdleFIFO";
 
 /**
  * Hook to render a report component based on its name.
@@ -14,17 +14,17 @@ import PHVObsoleteIdleFIFO from "../mainTopics/fifo/PHVObsoleteIdleFIFO";
  */
 export const useReportRenderer = () => {
 	return (subtopicName: string, repIdNo?: string): ReactNode => {
-		const repId = repIdNo?.trim() ?? "";
+		//const repId = repIdNo?.trim() ?? "";
 		// Some reports are known to use fixed repId numbers in the backend
 		// that don't always match registry lookups. Render the component
 		// directly for those repIds to avoid the generic fallback page.
-		if (repId === "14") {
-				return <CcApplicationProgress />;
-			}
+		// if (repId === "14") {
+		// 		return <CcApplicationProgress />;
+		// 	}
 
-		if (repId === "103") {
-			return <PHVObsoleteIdleFIFO />;
-		}
+		// if (repId === "103") {
+		// 	return <PHVObsoleteIdleFIFO />;
+		// }
 
 		const normalized = normalizeReportName(subtopicName);
 		const withoutLeadingNumber = normalizeReportName(

--- a/src/hooks/useReportScope.ts
+++ b/src/hooks/useReportScope.ts
@@ -1,0 +1,27 @@
+import { useUser } from "../contexts/UserContext";
+
+export type Category = "Area" | "Province" | "Region" | "Entire CEB";
+interface LockedValue { code: string; name: string; }
+
+export function useReportScope() {
+  const { user } = useUser();
+  const level = user.Level ?? 0;
+
+  let allowedCategories: Category[];
+  const locked: Partial<Record<Category, LockedValue>> = {};
+
+  if (level >= 80) {
+    allowedCategories = ["Area", "Province", "Region", "Entire CEB"];
+  } else if (level >= 70) {
+    allowedCategories = ["Area", "Province", "Region"];
+    locked["Region"] = { code: user.RegionCode || "", name: "" };
+  } else if (level >= 60) {
+    allowedCategories = ["Area", "Province"];
+    locked["Province"] = { code: user.ProvinceCode || "", name: user.ProvinceName || "" };
+  } else {
+    allowedCategories = ["Area"];
+    locked["Area"] = { code: user.AreaCode || "", name: user.AreaName || "" };
+  }
+
+  return { level, allowedCategories, locked };
+}

--- a/src/mainTopics/SolarInformation/RoofTopSolarInputData.tsx
+++ b/src/mainTopics/SolarInformation/RoofTopSolarInputData.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   AreaCode: string;
   AreaName: string;
+  ProvCode?: string;
+  Region?: string;
   ErrorMessage?: string | null;
 }
 
@@ -64,6 +68,9 @@ const RoofTopSolarInputData: React.FC = () => {
 
   const [reportData, setReportData] = useState<RoofTopSolarInputDataModel[]>([]);
 
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
+
   const printRef = useRef<HTMLDivElement>(null);
 
   // ─── fetch helpers ────────────────────────────────────────────────────────
@@ -102,36 +109,46 @@ const RoofTopSolarInputData: React.FC = () => {
   // ─── data fetches ─────────────────────────────────────────────────────────
 
   useEffect(() => {
-    const fetch = async () => {
-      setIsLoadingAreas(true);
-      setAreaError(null);
-      try {
-        const data = await fetchWithErrorHandling("/misapi/api/ordinary/areas");
-        setAreas(data.data || []);
-      } catch (err: any) {
-        setAreaError(err.message || "Failed to load areas.");
-      } finally {
-        setIsLoadingAreas(false);
+  const fetch = async () => {
+    setIsLoadingAreas(true);
+    setAreaError(null);
+    try {
+      let url = "/misapi/api/ordinary/areas";
+      if (locked["Region"]?.code) {
+        url += `?regionCode=${locked["Region"].code}`;
+      } else if (locked["Province"]?.code) {
+        url += `?provCode=${locked["Province"].code}`;
       }
-    };
-    fetch();
-  }, []);
+      const data = await fetchWithErrorHandling(url);
+      setAreas(data.data || []);
+    } catch (err: any) {
+      setAreaError(err.message || "Failed to load areas.");
+    } finally {
+      setIsLoadingAreas(false);
+    }
+  };
+  fetch();
+}, [user.Level]); // re-fetch if the logged-in user changes
 
-  useEffect(() => {
-    const fetch = async () => {
-      setIsLoadingProvinces(true);
-      setProvinceError(null);
-      try {
-        const data = await fetchWithErrorHandling("/misapi/api/ordinary/province");
-        setProvinces(data.data || []);
-      } catch (err: any) {
-        setProvinceError(err.message || "Failed to load provinces.");
-      } finally {
-        setIsLoadingProvinces(false);
+useEffect(() => {
+  const fetch = async () => {
+    setIsLoadingProvinces(true);
+    setProvinceError(null);
+    try {
+      let url = "/misapi/api/ordinary/province";
+      if (locked["Region"]?.code) {
+        url += `?regionCode=${locked["Region"].code}`;
       }
-    };
-    fetch();
-  }, []);
+      const data = await fetchWithErrorHandling(url);
+      setProvinces(data.data || []);
+    } catch (err: any) {
+      setProvinceError(err.message || "Failed to load provinces.");
+    } finally {
+      setIsLoadingProvinces(false);
+    }
+  };
+  fetch();
+}, [user.Level]);
 
   useEffect(() => {
     const fetch = async () => {
@@ -173,6 +190,15 @@ const RoofTopSolarInputData: React.FC = () => {
     fetch();
   }, []);
 
+
+  useEffect(() => {
+    const lock = locked[selectedCategory as keyof typeof locked];
+    if (lock) {
+      setCategoryValue(lock.code);
+      setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+    }
+  }, [selectedCategory, locked]);
+
   // ─── handlers ─────────────────────────────────────────────────────────────
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -190,10 +216,10 @@ const RoofTopSolarInputData: React.FC = () => {
 
   const getReportTypeParam = () => {
     switch (selectedCategory) {
-      case "Area":     return "area";
+      case "Area": return "area";
       case "Province": return "province";
-      case "Region":   return "region";
-      default:         return "entireceb";
+      case "Region": return "region";
+      default: return "entireceb";
     }
   };
 
@@ -448,145 +474,165 @@ const RoofTopSolarInputData: React.FC = () => {
             Roof Top Solar Input Data Portal for Loss Calculations
           </h1>
           <form onSubmit={handleSubmit}>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
 
-            {/* Select Category */}
-            <div className="flex flex-col">
-              <label className={`text-xs font-medium mb-1 ${maroon}`}>
-                Select Category:
-              </label>
-              <select
-                value={selectedCategory}
-                onChange={handleCategoryChange}
-                className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-              >
-                <option value="Area">Area</option>
-                <option value="Province">Province</option>
-                <option value="Region">Region</option>
-                <option value="Entire CEB">Entire CEB</option>
-              </select>
-            </div>
-
-            {/* Select Report Type (Area / Province / Region value) */}
-            {selectedCategory !== "Entire CEB" && (
+              {/* Select Category */}
               <div className="flex flex-col">
                 <label className={`text-xs font-medium mb-1 ${maroon}`}>
-                  Select{" "}
-                  {selectedCategory === "Area"
-                    ? "Area"
-                    : selectedCategory === "Province"
-                    ? "Province"
-                    : "Region"}
-                  :
+                  Select Category:
                 </label>
-
-                {selectedCategory === "Area" && (
-                  <select
-                    value={categoryValue}
-                    onChange={(e) => {
-                      const selected = areas.find(
-                        (a) => a.AreaCode === e.target.value
-                      );
-                      setCategoryValue(e.target.value);
-                      setSelectedCategoryName(
-                        selected
-                          ? `${selected.AreaCode} - ${selected.AreaName}`
-                          : ""
-                      );
-                    }}
-                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                      isLoadingAreas
-                        ? "bg-gray-100 text-gray-400 border-gray-200"
-                        : "border-gray-300"
-                    }`}
-                    disabled={isLoadingAreas}
-                  >
-                    <option value="">
-                      {isLoadingAreas ? "Loading..." : "Select Area"}
-                    </option>
-                    {areaError && (
-                      <option disabled value="">
-                        {areaError}
-                      </option>
-                    )}
-                    {areas.map((area) => (
-                      <option key={area.AreaCode} value={area.AreaCode}>
-                        {area.AreaCode} - {area.AreaName}
-                      </option>
-                    ))}
-                  </select>
-                )}
-
-                {selectedCategory === "Province" && (
-                  <select
-                    value={categoryValue}
-                    onChange={(e) => {
-                      const selected = provinces.find(
-                        (p) => p.ProvinceCode === e.target.value
-                      );
-                      setCategoryValue(e.target.value);
-                      setSelectedCategoryName(
-                        selected
-                          ? `${selected.ProvinceCode} - ${selected.ProvinceName}`
-                          : ""
-                      );
-                    }}
-                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                      isLoadingProvinces
-                        ? "bg-gray-100 text-gray-400 border-gray-200"
-                        : "border-gray-300"
-                    }`}
-                    disabled={isLoadingProvinces}
-                  >
-                    <option value="">
-                      {isLoadingProvinces ? "Loading..." : "Select Province"}
-                    </option>
-                    {provinceError && (
-                      <option disabled value="">
-                        {provinceError}
-                      </option>
-                    )}
-                    {provinces.map((prov) => (
-                      <option key={prov.ProvinceCode} value={prov.ProvinceCode}>
-                        {prov.ProvinceCode} - {prov.ProvinceName}
-                      </option>
-                    ))}
-                  </select>
-                )}
-
-                {selectedCategory === "Region" && (
-                  <select
-                    value={categoryValue}
-                    onChange={(e) => {
-                      setCategoryValue(e.target.value);
-                      setSelectedCategoryName(e.target.value);
-                    }}
-                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                      isLoadingDivisions
-                        ? "bg-gray-100 text-gray-400 border-gray-200"
-                        : "border-gray-300"
-                    }`}
-                    disabled={isLoadingDivisions}
-                  >
-                    <option value="">
-                      {isLoadingDivisions ? "Loading..." : "Select Region"}
-                    </option>
-                    {divisionError && (
-                      <option disabled value="">
-                        {divisionError}
-                      </option>
-                    )}
-                    {divisions.map((div) => (
-                      <option key={div.RegionCode} value={div.RegionCode}>
-                        {div.RegionCode}
-                      </option>
-                    ))}
-                  </select>
-                )}
+                <select
+                  value={selectedCategory}
+                  onChange={handleCategoryChange}
+                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+                >
+                  {allowedCategories.map((cat) => (
+                    <option key={cat} value={cat}>{cat}</option>
+                  ))}
+                </select>
               </div>
-            )}
 
-            {/* Calc Cycle
+              {/* Select Report Type (Area / Province / Region value) */}
+              {selectedCategory !== "Entire CEB" && (
+                <div className="flex flex-col">
+                  <label className={`text-xs font-medium mb-1 ${maroon}`}>
+                    Select{" "}
+                    {selectedCategory === "Area"
+                      ? "Area"
+                      : selectedCategory === "Province"
+                        ? "Province"
+                        : "Region"}
+                    :
+                  </label>
+
+                  {selectedCategory === "Area" && (
+                    locked["Area"] ? (
+                      <select disabled value={locked["Area"].code} className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-600 border-gray-200 cursor-not-allowed">
+                        <option value={locked["Area"].code}>
+                          {locked["Area"].code} - {locked["Area"].name}
+                        </option>
+                      </select>
+                    ) : (
+                      <select
+                        value={categoryValue}
+                        onChange={(e) => {
+                          const selected = areas.find(
+                            (a) => a.AreaCode === e.target.value
+                          );
+                          setCategoryValue(e.target.value);
+                          setSelectedCategoryName(
+                            selected
+                              ? `${selected.AreaCode} - ${selected.AreaName}`
+                              : ""
+                          );
+                        }}
+                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isLoadingAreas
+                          ? "bg-gray-100 text-gray-400 border-gray-200"
+                          : "border-gray-300"
+                          }`}
+                        disabled={isLoadingAreas}
+                      >
+                        <option value="">
+                          {isLoadingAreas ? "Loading..." : "Select Area"}
+                        </option>
+                        {areaError && (
+                          <option disabled value="">
+                            {areaError}
+                          </option>
+                        )}
+                        {areas.map((area) => (
+                          <option key={area.AreaCode} value={area.AreaCode}>
+                            {area.AreaCode} - {area.AreaName}
+                          </option>
+                        ))}
+                      </select>
+                    )
+                  )}
+
+                  {selectedCategory === "Province" && (
+                    locked["Province"] ? (
+                      <select disabled value={locked["Province"].code} className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-600 border-gray-200 cursor-not-allowed">
+                        <option value={locked["Province"].code}>
+                          {locked["Province"].code} - {locked["Province"].name}
+                        </option>
+                      </select>
+                    ) : (
+                      <select
+                        value={categoryValue}
+                        onChange={(e) => {
+                          const selected = provinces.find(
+                            (p) => p.ProvinceCode === e.target.value
+                          );
+                          setCategoryValue(e.target.value);
+                          setSelectedCategoryName(
+                            selected
+                              ? `${selected.ProvinceCode} - ${selected.ProvinceName}`
+                              : ""
+                          );
+                        }}
+                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isLoadingProvinces
+                          ? "bg-gray-100 text-gray-400 border-gray-200"
+                          : "border-gray-300"
+                          }`}
+                        disabled={isLoadingProvinces}
+                      >
+                        <option value="">
+                          {isLoadingProvinces ? "Loading..." : "Select Province"}
+                        </option>
+                        {provinceError && (
+                          <option disabled value="">
+                            {provinceError}
+                          </option>
+                        )}
+                        {provinces.map((prov) => (
+                          <option key={prov.ProvinceCode} value={prov.ProvinceCode}>
+                            {prov.ProvinceCode} - {prov.ProvinceName}
+                          </option>
+                        ))}
+                      </select>
+                    )
+                  )}
+
+                  {selectedCategory === "Region" && (
+                    locked["Region"] ? (
+                      <select disabled value={locked["Region"].code} className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-600 border-gray-200 cursor-not-allowed">
+                        <option value={locked["Region"].code}>
+                          {locked["Region"].name ? `${locked["Region"].code} - ${locked["Region"].name}` : locked["Region"].code}
+                        </option>
+                      </select>
+                    ) : (
+                      <select
+                        value={categoryValue}
+                        onChange={(e) => {
+                          setCategoryValue(e.target.value);
+                          setSelectedCategoryName(e.target.value);
+                        }}
+                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isLoadingDivisions
+                          ? "bg-gray-100 text-gray-400 border-gray-200"
+                          : "border-gray-300"
+                          }`}
+                        disabled={isLoadingDivisions}
+                      >
+                        <option value="">
+                          {isLoadingDivisions ? "Loading..." : "Select Region"}
+                        </option>
+                        {divisionError && (
+                          <option disabled value="">
+                            {divisionError}
+                          </option>
+                        )}
+                        {divisions.map((div) => (
+                          <option key={div.RegionCode} value={div.RegionCode}>
+                            {div.RegionCode}
+                          </option>
+                        ))}
+                      </select>
+                    )
+                  )}
+                </div>
+              )}
+
+              {/* Calc Cycle
             <div className="flex flex-col">
               <label className={`text-xs font-medium mb-1 ${maroon}`}>
                 Calc Cycle:
@@ -623,99 +669,96 @@ const RoofTopSolarInputData: React.FC = () => {
               </select>
             </div> */}
 
-            {/* Calc Cycle */}
-            <div className="flex flex-col">
-              <label
-                className={`text-xs font-medium mb-1 ${
-                  isLoadingCycles ||
-                  cycleError !== null ||
-                  (selectedCategory !== "Entire CEB" && !categoryValue)
+              {/* Calc Cycle */}
+              <div className="flex flex-col">
+                <label
+                  className={`text-xs font-medium mb-1 ${isLoadingCycles ||
+                    cycleError !== null ||
+                    (selectedCategory !== "Entire CEB" && !categoryValue)
                     ? "text-gray-400"
                     : maroon
-                }`}
-              >
-                Calc Cycle:
-              </label>
-              <select
-                value={calcCycleValue}
-                onChange={(e) => {
-                  const selected = cycleOptions.find(
-                    (c) => c.code === e.target.value
-                  );
-                  setCalcCycleValue(e.target.value);
-                  setSelectedCycleDisplay(selected?.display ?? "");
-                }}
-                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                  isLoadingCycles ||
-                  cycleError !== null ||
-                  (selectedCategory !== "Entire CEB" && !categoryValue)
+                    }`}
+                >
+                  Calc Cycle:
+                </label>
+                <select
+                  value={calcCycleValue}
+                  onChange={(e) => {
+                    const selected = cycleOptions.find(
+                      (c) => c.code === e.target.value
+                    );
+                    setCalcCycleValue(e.target.value);
+                    setSelectedCycleDisplay(selected?.display ?? "");
+                  }}
+                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isLoadingCycles ||
+                    cycleError !== null ||
+                    (selectedCategory !== "Entire CEB" && !categoryValue)
                     ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                     : "border-gray-300"
-                }`}
-                disabled={
-                  isLoadingCycles ||
-                  cycleError !== null ||
-                  (selectedCategory !== "Entire CEB" && !categoryValue)
-                }
-              >
-                <option value="">
-                  {isLoadingCycles ? "Loading..." : "Select Calc Cycle"}
-                </option>
-                {cycleError && (
-                  <option disabled value="">
-                    {cycleError}
+                    }`}
+                  disabled={
+                    isLoadingCycles ||
+                    cycleError !== null ||
+                    (selectedCategory !== "Entire CEB" && !categoryValue)
+                  }
+                >
+                  <option value="">
+                    {isLoadingCycles ? "Loading..." : "Select Calc Cycle"}
                   </option>
-                )}
-                {cycleOptions.map((opt) => (
-                  <option key={opt.code} value={opt.code}>
-                    {opt.display}
-                  </option>
-                ))}
-              </select>
+                  {cycleError && (
+                    <option disabled value="">
+                      {cycleError}
+                    </option>
+                  )}
+                  {cycleOptions.map((opt) => (
+                    <option key={opt.code} value={opt.code}>
+                      {opt.display}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
-          </div>
 
-          {/* Submit */}
-          <div className="w-full mt-6 flex justify-end">
-            <button
-              type="submit"
-              className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${
-                loading || !canSubmit()
+            {/* Submit */}
+            <div className="w-full mt-6 flex justify-end">
+              <button
+                type="submit"
+                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${loading || !canSubmit()
                   ? "opacity-70 cursor-not-allowed"
                   : "hover:opacity-90"
-              }`}
-              disabled={loading || !canSubmit()}
-            >
-              {loading ? (
-                <span className="flex items-center">
-                  <svg
-                    className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  Loading...
-                </span>
-              ) : (
-                "Generate Report"
-              )}
-            </button>
-          </div>
-        </form>
+                  }`}
+                disabled={loading || !canSubmit()}
+              >
+                {loading ? (
+                  <span className="flex items-center">
+                    <svg
+                      className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Loading...
+                  </span>
+                ) : (
+                  "Generate Report"
+                )}
+              </button>
+            </div>
+          </form>
         </>
       )}
 

--- a/src/mainTopics/SolarInformation/SolarConnectionDetailsBulk.tsx
+++ b/src/mainTopics/SolarInformation/SolarConnectionDetailsBulk.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
     AreaCode: string;
@@ -86,6 +88,9 @@ const SolarConnectionDetailsBulk: React.FC = () => {
     // Report data
     const [reportData, setReportData] = useState<BulkUsageData[]>([]);
 
+    const { user } = useUser();
+    const { allowedCategories, locked } = useReportScope();
+
     const printRef = useRef<HTMLDivElement>(null);
 
     // Helper function for error handling
@@ -135,16 +140,16 @@ const SolarConnectionDetailsBulk: React.FC = () => {
     };
 
     // Convert net type code to display name
-const getNetTypeDisplayName = (netTypeCode: string): string => {
-    const netTypeMap: { [key: string]: string } = {
-        "1": "Net Metering",
-        "2": "Net Accounting", 
-        "3": "Net Plus",
-        "4": "Net Plus Plus",
-        //"5": "Convert Net Metering to Net Accounting"
+    const getNetTypeDisplayName = (netTypeCode: string): string => {
+        const netTypeMap: { [key: string]: string } = {
+            "1": "Net Metering",
+            "2": "Net Accounting",
+            "3": "Net Plus",
+            "4": "Net Plus Plus",
+            //"5": "Convert Net Metering to Net Accounting"
+        };
+        return netTypeMap[netTypeCode] || netTypeCode; // Fallback to the code if not found
     };
-    return netTypeMap[netTypeCode] || netTypeCode; // Fallback to the code if not found
-};
 
     // Format number with comma separators
     const formatNumber = (num: number, decimals: number = 2): string => {
@@ -182,7 +187,7 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
         });
     };
 
-    
+
 
     // Fetch bill cycles
     useEffect(() => {
@@ -191,13 +196,13 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
             setBillCycleError(null);
             try {
                 const response = await fetchWithErrorHandling("/misapi/api/bulk/netmtcons/billcycle/max");
-                
+
                 const billCyclesArray = response?.data?.BillCycles;
                 const maxBillCycle = response?.data?.MaxBillCycle;
-                
+
                 if (billCyclesArray && Array.isArray(billCyclesArray) && maxBillCycle) {
                     const maxCycleNum = parseInt(maxBillCycle);
-                    
+
                     const options: BillCycleOption[] = billCyclesArray.map((cycle: string, index: number) => {
                         const cycleNumber = maxCycleNum - index;
                         return {
@@ -205,7 +210,7 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                             code: cycleNumber.toString(),
                         };
                     });
-                    
+
                     setBillCycleOptions(options);
                 } else {
                     throw new Error("Invalid bill cycle data format");
@@ -227,7 +232,13 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
             setIsLoadingAreas(true);
             setAreaError(null);
             try {
-                const response = await fetchWithErrorHandling("/misapi/api/bulk/areas");
+                let url = "/misapi/api/bulk/areas";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                } else if (locked["Province"]?.code) {
+                    url += `?provCode=${locked["Province"].code}`;
+                }
+                const response = await fetchWithErrorHandling(url);
                 if (response?.data && Array.isArray(response.data)) {
                     setAreas(response.data);
                 } else {
@@ -244,7 +255,7 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
         if (reportCategory === "Area") {
             fetchAreas();
         }
-    }, [reportCategory]);
+    }, [reportCategory, user.Level, user.RegionCode, user.ProvinceCode]);
 
     // Fetch provinces
     useEffect(() => {
@@ -252,7 +263,11 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
             setIsLoadingProvinces(true);
             setProvinceError(null);
             try {
-                const response = await fetchWithErrorHandling("/misapi/api/bulk/province");
+                let url = "/misapi/api/bulk/province";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                }
+                const response = await fetchWithErrorHandling(url);
                 if (response?.data && Array.isArray(response.data)) {
                     setProvinces(response.data);
                 } else {
@@ -269,7 +284,7 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
         if (reportCategory === "Province") {
             fetchProvinces();
         }
-    }, [reportCategory]);
+    }, [reportCategory, user.Level, user.RegionCode]);
 
     // Fetch divisions
     useEffect(() => {
@@ -295,6 +310,16 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
             fetchDivisions();
         }
     }, [reportCategory]);
+
+
+    useEffect(() => {
+        const key = reportCategory === "Division" ? "Region" : reportCategory;
+        const lock = locked[key as keyof typeof locked];
+        if (lock) {
+            setCategoryValue(lock.code);
+            setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+        }
+    }, [reportCategory, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
     // Format division option
     const formatDivisionOption = (division: Division): string => {
@@ -326,7 +351,7 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
 
         try {
             const netTypeCode = getNetTypeCode(netType);
-            
+
             // Determine report type for API
             let reportTypeParam = "";
             let typeCodeParam = "";
@@ -355,7 +380,7 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
             if (response?.data && Array.isArray(response.data)) {
                 const sortedData = sortDataAlphabetically(response.data);
                 setReportData(sortedData);
-                
+
                 // Set display values
                 if (reportCategory === "Area") {
                     const selectedArea = areas.find(a => a.AreaCode === categoryValue);
@@ -524,8 +549,8 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
         if (!printWindow) return;
 
         const reportTitle = "SOLAR CONNECTION DETAILS (INCL. READING AND USAGE) - BULK";
-        const categoryInfo = reportCategory === "Entire CEB" 
-            ? "Entire CEB" 
+        const categoryInfo = reportCategory === "Entire CEB"
+            ? "Entire CEB"
             : `${reportCategory}: <span class="bold">${selectedCategoryName}</span>`;
         const selectionInfo = `${categoryInfo}<br>Month: <span class="bold">${selectedBillCycleDisplay}</span><br>Net Type: <span class="bold">${netType}</span>`;
 
@@ -780,14 +805,14 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
 
     return (
         <div className="p-6 bg-white rounded-lg shadow-md">
-            
+
 
             {/* Form Section */}
             {!reportVisible && (
                 <>
-                <h2 className={`text-xl font-bold mb-6 ${maroon}`}>
-                Solar Connection Details (incl. reading and usage) - Bulk
-            </h2>
+                    <h2 className={`text-xl font-bold mb-6 ${maroon}`}>
+                        Solar Connection Details (incl. reading and usage) - Bulk
+                    </h2>
                     <form onSubmit={handleSubmit} className="space-y-4">
                         {/* First Row - Month, Net Type, Report Category */}
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -824,9 +849,8 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                             {/* Select Net Type Dropdown */}
                             <div className="flex flex-col">
                                 <label
-                                    className={`text-xs font-medium mb-1 ${
-                                        isNetTypeDisabled() ? "text-gray-400" : maroon
-                                    }`}
+                                    className={`text-xs font-medium mb-1 ${isNetTypeDisabled() ? "text-gray-400" : maroon
+                                        }`}
                                 >
                                     Select Net Type:
                                 </label>
@@ -836,11 +860,10 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                                         setNetType(e.target.value);
                                         setCategoryValue("");
                                     }}
-                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                        isNetTypeDisabled()
-                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                            : "border-gray-300"
-                                    }`}
+                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isNetTypeDisabled()
+                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        : "border-gray-300"
+                                        }`}
                                     required
                                     disabled={isNetTypeDisabled()}
                                 >
@@ -855,9 +878,8 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                             {/* Select Report Category Dropdown */}
                             <div className="flex flex-col">
                                 <label
-                                    className={`text-xs font-medium mb-1 ${
-                                        isCategoryValueDisabled() ? "text-gray-400" : maroon
-                                    }`}
+                                    className={`text-xs font-medium mb-1 ${isCategoryValueDisabled() ? "text-gray-400" : maroon
+                                        }`}
                                 >
                                     Select Report Category:
                                 </label>
@@ -867,18 +889,18 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                                         setReportCategory(e.target.value);
                                         setCategoryValue("");
                                     }}
-                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                        isCategoryValueDisabled()
-                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                            : "border-gray-300"
-                                    }`}
+                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
+                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        : "border-gray-300"
+                                        }`}
                                     required
                                     disabled={isCategoryValueDisabled()}
                                 >
-                                    <option value="Area">Area</option>
-                                    <option value="Province">Province</option>
-                                    <option value="Division">Division</option>
-                                    <option value="Entire CEB">Entire CEB</option>
+                                    {allowedCategories.map((cat) => (
+                                        <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                                            {cat === "Region" ? "Division" : cat}
+                                        </option>
+                                    ))}
                                 </select>
                             </div>
                         </div>
@@ -888,97 +910,121 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                                 <div className="flex flex-col">
                                     <label
-                                        className={`text-xs font-medium mb-1 ${
-                                            isCategoryValueDisabled() ? "text-gray-400" : maroon
-                                        }`}
+                                        className={`text-xs font-medium mb-1 ${isCategoryValueDisabled() ? "text-gray-400" : maroon
+                                            }`}
                                     >
                                         {reportCategory === "Area" && "Select Area:"}
                                         {reportCategory === "Province" && "Select Province:"}
                                         {reportCategory === "Division" && "Select Division:"}
                                     </label>
                                     {reportCategory === "Area" && (
-                                        <select
-                                            value={categoryValue}
-                                            onChange={(e) => setCategoryValue(e.target.value)}
-                                            className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                                isCategoryValueDisabled()
+                                        locked["Area"] ? (
+                                            <select
+                                                disabled
+                                                value={locked["Area"].code}
+                                                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                            >
+                                                <option value={locked["Area"].code}>
+                                                    {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                                                </option>
+                                            </select>
+                                        ) : (
+                                            <select
+                                                value={categoryValue}
+                                                onChange={(e) => setCategoryValue(e.target.value)}
+                                                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
                                                     ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                                                     : "border-gray-300"
-                                            }`}
-                                            required
-                                            disabled={isCategoryValueDisabled()}
-                                        >
-                                            <option value="">Select Area</option>
-                                            {isLoadingAreas ? (
-                                                <option value="">Loading...</option>
-                                            ) : areaError ? (
-                                                <option value="">Error loading areas</option>
-                                            ) : (
-                                                areas.map((area) => (
-                                                    <option key={area.AreaCode} value={area.AreaCode}>
-                                                        {area.AreaCode} - {area.AreaName}
-                                                    </option>
-                                                ))
-                                            )}
-                                        </select>
+                                                    }`}
+                                                required
+                                                disabled={isCategoryValueDisabled()}
+                                            >
+                                                <option value="">Select Area</option>
+                                                {isLoadingAreas ? (
+                                                    <option value="">Loading...</option>
+                                                ) : areaError ? (
+                                                    <option value="">Error loading areas</option>
+                                                ) : (
+                                                    areas.map((area) => (
+                                                        <option key={area.AreaCode} value={area.AreaCode}>
+                                                            {area.AreaCode} - {area.AreaName}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
+                                        )
                                     )}
                                     {reportCategory === "Province" && (
-                                        <select
-                                            value={categoryValue}
-                                            onChange={(e) => setCategoryValue(e.target.value)}
-                                            className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                                isCategoryValueDisabled()
+                                        locked["Province"] ? (
+                                            <select
+                                                disabled
+                                                value={locked["Province"].code}
+                                                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                            >
+                                                <option value={locked["Province"].code}>
+                                                    {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                                                </option>
+                                            </select>
+                                        ) : (
+                                            <select
+                                                value={categoryValue}
+                                                onChange={(e) => setCategoryValue(e.target.value)}
+                                                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
                                                     ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                                                     : "border-gray-300"
-                                            }`}
-                                            required
-                                            disabled={isCategoryValueDisabled()}
-                                        >
-                                            <option value="">Select Province</option>
-                                            {isLoadingProvinces ? (
-                                                <option value="">Loading...</option>
-                                            ) : provinceError ? (
-                                                <option value="">Error loading provinces</option>
-                                            ) : (
-                                                provinces.map((province) => (
-                                                    <option
-                                                        key={province.ProvinceCode}
-                                                        value={province.ProvinceCode}
-                                                    >
-                                                        {province.ProvinceCode} - {province.ProvinceName}
-                                                    </option>
-                                                ))
-                                            )}
-                                        </select>
+                                                    }`}
+                                                required
+                                                disabled={isCategoryValueDisabled()}
+                                            >
+                                                <option value="">Select Province</option>
+                                                {isLoadingProvinces ? (
+                                                    <option value="">Loading...</option>
+                                                ) : provinceError ? (
+                                                    <option value="">Error loading provinces</option>
+                                                ) : (
+                                                    provinces.map((province) => (
+                                                        <option key={province.ProvinceCode} value={province.ProvinceCode}>
+                                                            {province.ProvinceCode} - {province.ProvinceName}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
+                                        )
                                     )}
                                     {reportCategory === "Division" && (
-                                        <select
-                                            value={categoryValue}
-                                            onChange={(e) => setCategoryValue(e.target.value)}
-                                            className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                                isCategoryValueDisabled()
+                                        locked["Region"] ? (
+                                            <select
+                                                disabled
+                                                value={locked["Region"].code}
+                                                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                            >
+                                                <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                                            </select>
+                                        ) : (
+                                            <select
+                                                value={categoryValue}
+                                                onChange={(e) => setCategoryValue(e.target.value)}
+                                                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
                                                     ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                                                     : "border-gray-300"
-                                            }`}
-                                            required
-                                            disabled={isCategoryValueDisabled()}
-                                        >
-                                            <option value="">Select Division</option>
-                                            {isLoadingDivisions ? (
-                                                <option value="">Loading...</option>
-                                            ) : divisionError ? (
-                                                <option value="">Error loading divisions</option>
-                                            ) : (
-                                                divisions.map((division) => (
-                                                    <option
-                                                        key={division.RegionCode}
-                                                        value={division.RegionCode}
-                                                    >
-                                                        {formatDivisionOption(division)}
-                                                    </option>
-                                                ))
-                                            )}
-                                        </select>
+                                                    }`}
+                                                required
+                                                disabled={isCategoryValueDisabled()}
+                                            >
+                                                <option value="">Select Division</option>
+                                                {isLoadingDivisions ? (
+                                                    <option value="">Loading...</option>
+                                                ) : divisionError ? (
+                                                    <option value="">Error loading divisions</option>
+                                                ) : (
+                                                    divisions.map((division) => (
+                                                        <option key={division.RegionCode} value={division.RegionCode}>
+                                                            {formatDivisionOption(division)}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
+                                        )
                                     )}
                                 </div>
                             </div>
@@ -988,11 +1034,10 @@ const getNetTypeDisplayName = (netTypeCode: string): string => {
                         <div className="w-full mt-6 flex justify-end">
                             <button
                                 type="submit"
-                                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${
-                                    loading || !canSubmit()
-                                        ? "opacity-70 cursor-not-allowed"
-                                        : "hover:opacity-90"
-                                }`}
+                                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${loading || !canSubmit()
+                                    ? "opacity-70 cursor-not-allowed"
+                                    : "hover:opacity-90"
+                                    }`}
                                 disabled={loading || !canSubmit()}
                             >
                                 {loading ? (

--- a/src/mainTopics/SolarInformation/SolarConnectionDetailsRetail.tsx
+++ b/src/mainTopics/SolarInformation/SolarConnectionDetailsRetail.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
     AreaCode: string;
@@ -101,6 +103,9 @@ const SolarConnectionDetailsRetail: React.FC = () => {
     // Report data
     const [detailedData, setDetailedData] = useState<DetailedConnectionData[]>([]);
     const [summaryData, setSummaryData] = useState<SummaryConnectionData[]>([]);
+
+    const { user } = useUser();
+    const { allowedCategories, locked } = useReportScope();
 
     const printRef = useRef<HTMLDivElement>(null);
 
@@ -529,9 +534,13 @@ const SolarConnectionDetailsRetail: React.FC = () => {
             setIsLoadingAreas(true);
             setAreaError(null);
             try {
-                const data = await fetchWithErrorHandling(
-                    "/misapi/api/ordinary/areas"
-                );
+                let url = "/misapi/api/ordinary/areas";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                } else if (locked["Province"]?.code) {
+                    url += `?provCode=${locked["Province"].code}`;
+                }
+                const data = await fetchWithErrorHandling(url);
                 if (data.errorMessage) {
                     setAreaError(data.errorMessage);
                 } else {
@@ -539,9 +548,7 @@ const SolarConnectionDetailsRetail: React.FC = () => {
                 }
             } catch (error) {
                 setAreaError(
-                    error instanceof Error
-                        ? error.message
-                        : "Failed to load areas"
+                    error instanceof Error ? error.message : "Failed to load areas"
                 );
             } finally {
                 setIsLoadingAreas(false);
@@ -549,7 +556,7 @@ const SolarConnectionDetailsRetail: React.FC = () => {
         };
 
         fetchAreas();
-    }, []);
+    }, [user.Level]);
 
     // Fetch provinces
     useEffect(() => {
@@ -557,9 +564,11 @@ const SolarConnectionDetailsRetail: React.FC = () => {
             setIsLoadingProvinces(true);
             setProvinceError(null);
             try {
-                const data = await fetchWithErrorHandling(
-                    "/misapi/api/ordinary/province"
-                );
+                let url = "/misapi/api/ordinary/province";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                }
+                const data = await fetchWithErrorHandling(url);
                 if (data.errorMessage) {
                     setProvinceError(data.errorMessage);
                 } else {
@@ -567,9 +576,7 @@ const SolarConnectionDetailsRetail: React.FC = () => {
                 }
             } catch (error) {
                 setProvinceError(
-                    error instanceof Error
-                        ? error.message
-                        : "Failed to load provinces"
+                    error instanceof Error ? error.message : "Failed to load provinces"
                 );
             } finally {
                 setIsLoadingProvinces(false);
@@ -577,7 +584,7 @@ const SolarConnectionDetailsRetail: React.FC = () => {
         };
 
         fetchProvinces();
-    }, []);
+    }, [user.Level]);
 
     // Fetch divisions
     useEffect(() => {
@@ -606,6 +613,15 @@ const SolarConnectionDetailsRetail: React.FC = () => {
 
         fetchDivisions();
     }, []);
+
+    useEffect(() => {
+        const key = selectedCategory === "Division" ? "Region" : selectedCategory;
+        const lock = locked[key as keyof typeof locked];
+        if (lock) {
+            setCategoryValue(lock.code);
+            setSelectedCategoryName?.(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+        }
+    }, [selectedCategory, locked]);
 
     // Fetch cycles when cycle type changes
     useEffect(() => {
@@ -1323,10 +1339,11 @@ const SolarConnectionDetailsRetail: React.FC = () => {
                                     required
                                     disabled={isReportCategoryDisabled()}
                                 >
-                                    <option value="Area">Area</option>
-                                    <option value="Province">Province</option>
-                                    <option value="Division">Division</option>
-                                    <option value="Entire CEB">Entire CEB</option>
+                                    {allowedCategories.map((cat) => (
+                                        <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                                            {cat === "Region" ? "Division" : cat}
+                                        </option>
+                                    ))}
                                 </select>
                             </div>
 
@@ -1340,91 +1357,116 @@ const SolarConnectionDetailsRetail: React.FC = () => {
                                         Select {selectedCategory}:
                                     </label>
                                     {selectedCategory === "Area" && (
-                                        <select
-                                            value={categoryValue}
-                                            onChange={(e) => setCategoryValue(e.target.value)}
-                                            className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
+                                        locked["Area"] ? (
+                                            <select
+                                                disabled
+                                                value={locked["Area"].code}
+                                                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                            >
+                                                <option value={locked["Area"].code}>
+                                                    {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                                                </option>
+                                            </select>
+                                        ) : (
+                                            <select
+                                                value={categoryValue}
+                                                onChange={(e) => setCategoryValue(e.target.value)}
+                                                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
                         ${isCategoryValueDisabled()
-                                                    ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                    : "border-gray-300"
-                                                }`}
-                                            required
-                                            disabled={isCategoryValueDisabled()}
-                                        >
-                                            <option value="">Select Area</option>
-                                            {isLoadingAreas ? (
-                                                <option value="">Loading...</option>
-                                            ) : areaError ? (
-                                                <option value="">Error loading areas</option>
-                                            ) : (
-                                                areas.map((area) => (
-                                                    <option
-                                                        key={area.AreaCode}
-                                                        value={area.AreaCode}
-                                                    >
-                                                        {area.AreaCode} - {area.AreaName}
-                                                    </option>
-                                                ))
-                                            )}
-                                        </select>
+                                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                        : "border-gray-300"
+                                                    }`}
+                                                required
+                                                disabled={isCategoryValueDisabled()}
+                                            >
+                                                <option value="">Select Area</option>
+                                                {isLoadingAreas ? (
+                                                    <option value="">Loading...</option>
+                                                ) : areaError ? (
+                                                    <option value="">Error loading areas</option>
+                                                ) : (
+                                                    areas.map((area) => (
+                                                        <option key={area.AreaCode} value={area.AreaCode}>
+                                                            {area.AreaCode} - {area.AreaName}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
+                                        )
                                     )}
                                     {selectedCategory === "Province" && (
-                                        <select
-                                            value={categoryValue}
-                                            onChange={(e) => setCategoryValue(e.target.value)}
-                                            className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
+                                        locked["Province"] ? (
+                                            <select
+                                                disabled
+                                                value={locked["Province"].code}
+                                                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                            >
+                                                <option value={locked["Province"].code}>
+                                                    {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                                                </option>
+                                            </select>
+                                        ) : (
+                                            <select
+                                                value={categoryValue}
+                                                onChange={(e) => setCategoryValue(e.target.value)}
+                                                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
                         ${isCategoryValueDisabled()
-                                                    ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                    : "border-gray-300"
-                                                }`}
-                                            required
-                                            disabled={isCategoryValueDisabled()}
-                                        >
-                                            <option value="">Select Province</option>
-                                            {isLoadingProvinces ? (
-                                                <option value="">Loading...</option>
-                                            ) : provinceError ? (
-                                                <option value="">Error loading provinces</option>
-                                            ) : (
-                                                provinces.map((province) => (
-                                                    <option
-                                                        key={province.ProvinceCode}
-                                                        value={province.ProvinceCode}
-                                                    >
-                                                        {province.ProvinceCode} - {province.ProvinceName}
-                                                    </option>
-                                                ))
-                                            )}
-                                        </select>
+                                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                        : "border-gray-300"
+                                                    }`}
+                                                required
+                                                disabled={isCategoryValueDisabled()}
+                                            >
+                                                <option value="">Select Province</option>
+                                                {isLoadingProvinces ? (
+                                                    <option value="">Loading...</option>
+                                                ) : provinceError ? (
+                                                    <option value="">Error loading provinces</option>
+                                                ) : (
+                                                    provinces.map((province) => (
+                                                        <option key={province.ProvinceCode} value={province.ProvinceCode}>
+                                                            {province.ProvinceCode} - {province.ProvinceName}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
+                                        )
                                     )}
                                     {selectedCategory === "Division" && (
-                                        <select
-                                            value={categoryValue}
-                                            onChange={(e) => setCategoryValue(e.target.value)}
-                                            className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
+                                        locked["Region"] ? (
+                                            <select
+                                                disabled
+                                                value={locked["Region"].code}
+                                                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                            >
+                                                <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                                            </select>
+                                        ) : (
+                                            <select
+                                                value={categoryValue}
+                                                onChange={(e) => setCategoryValue(e.target.value)}
+                                                className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
                         ${isCategoryValueDisabled()
-                                                    ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                    : "border-gray-300"
-                                                }`}
-                                            required
-                                            disabled={isCategoryValueDisabled()}
-                                        >
-                                            <option value="">Select Division</option>
-                                            {isLoadingDivisions ? (
-                                                <option value="">Loading...</option>
-                                            ) : divisionError ? (
-                                                <option value="">Error loading divisions</option>
-                                            ) : (
-                                                divisions.map((division) => (
-                                                    <option
-                                                        key={division.RegionCode}
-                                                        value={division.RegionCode}
-                                                    >
-                                                        {formatDivisionOption(division)}
-                                                    </option>
-                                                ))
-                                            )}
-                                        </select>
+                                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                        : "border-gray-300"
+                                                    }`}
+                                                required
+                                                disabled={isCategoryValueDisabled()}
+                                            >
+                                                <option value="">Select Division</option>
+                                                {isLoadingDivisions ? (
+                                                    <option value="">Loading...</option>
+                                                ) : divisionError ? (
+                                                    <option value="">Error loading divisions</option>
+                                                ) : (
+                                                    divisions.map((division) => (
+                                                        <option key={division.RegionCode} value={division.RegionCode}>
+                                                            {formatDivisionOption(division)}
+                                                        </option>
+                                                    ))
+                                                )}
+                                            </select>
+                                        )
                                     )}
                                 </div>
                             )}

--- a/src/mainTopics/SolarInformation/SolarPVBilling.tsx
+++ b/src/mainTopics/SolarInformation/SolarPVBilling.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   AreaCode: string;
@@ -81,6 +83,9 @@ const SolarPVBilling: React.FC = () => {
   const [selectedCycleDisplay, setSelectedCycleDisplay] = useState<string>("");
   const [reportVisible, setReportVisible] = useState(false);
 
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
+
   // Report data
   const [detailedData, setDetailedData] = useState<DetailedPVConnection[]>([]);
   const [summaryData, setSummaryData] = useState<SummaryReportData>({
@@ -132,7 +137,7 @@ const SolarPVBilling: React.FC = () => {
   ): BillCycleOption[] => {
     const maxCycleNum = parseInt(maxCycle);
     return cycles.map((cycle, index) => ({
-      display: cycleType === "Calculation Cycle" 
+      display: cycleType === "Calculation Cycle"
         ? cycle  // Show only month-year for Calculation Cycle
         : `${(maxCycleNum - index).toString()} - ${cycle}`,  // Show full format for Bill Cycle
       code: (maxCycleNum - index).toString(),
@@ -145,7 +150,13 @@ const SolarPVBilling: React.FC = () => {
       setIsLoadingAreas(true);
       setAreaError(null);
       try {
-        const areaData = await fetchWithErrorHandling("/misapi/api/bulk/areas");
+        let url = "/misapi/api/bulk/areas";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          url += `?provCode=${locked["Province"].code}`;
+        }
+        const areaData = await fetchWithErrorHandling(url);
         setAreas(areaData.data || []);
       } catch (err: any) {
         console.error("Error fetching areas:", err);
@@ -158,7 +169,7 @@ const SolarPVBilling: React.FC = () => {
     };
 
     fetchAreas();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // Fetch provinces
   useEffect(() => {
@@ -166,7 +177,11 @@ const SolarPVBilling: React.FC = () => {
       setIsLoadingProvinces(true);
       setProvinceError(null);
       try {
-        const provinceData = await fetchWithErrorHandling("/misapi/api/bulk/province");
+        let url = "/misapi/api/bulk/province";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        }
+        const provinceData = await fetchWithErrorHandling(url);
         setProvinces(provinceData.data || []);
       } catch (err: any) {
         console.error("Error fetching provinces:", err);
@@ -179,7 +194,7 @@ const SolarPVBilling: React.FC = () => {
     };
 
     fetchProvinces();
-  }, []);
+  }, [user.Level, user.RegionCode]);
 
   // Fetch divisions
   useEffect(() => {
@@ -201,6 +216,14 @@ const SolarPVBilling: React.FC = () => {
 
     fetchDivisions();
   }, []);
+
+  useEffect(() => {
+    const lock = locked[selectedCategory as keyof typeof locked];
+    if (lock) {
+      setCategoryValue(lock.code);
+      setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+    }
+  }, [selectedCategory, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
   // Fetch cycles based on cycle type
   useEffect(() => {
@@ -289,8 +312,8 @@ const SolarPVBilling: React.FC = () => {
       selectedCategory === "Entire CEB"
         ? "Entire CEB"
         : selectedCategory === "Area"
-        ? `${selectedCategory}: ${selectedCategoryName}`
-        : `${selectedCategory}: ${categoryValue}`;
+          ? `${selectedCategory}: ${selectedCategoryName}`
+          : `${selectedCategory}: ${categoryValue}`;
 
     if (reportType.includes("Detailed")) {
       const isOrdinaryReport = reportType === "Detailed Report - Ordinary";
@@ -368,9 +391,8 @@ const SolarPVBilling: React.FC = () => {
       sortedData.forEach((item) => {
         const divisionKey = item.Division || "";
         const provinceKey = `${item.Division || ""}-${item.Province || ""}`;
-        const areaKey = `${item.Division || ""}-${item.Province || ""}-${
-          item.Area || ""
-        }`;
+        const areaKey = `${item.Division || ""}-${item.Province || ""}-${item.Area || ""
+          }`;
 
         if (!divisionGroups[divisionKey]) divisionGroups[divisionKey] = [];
         divisionGroups[divisionKey].push(item);
@@ -424,9 +446,8 @@ const SolarPVBilling: React.FC = () => {
                 currentArea = "";
               }
               if (areaValue) {
-                currentArea = `${row.Division || ""}-${row.Province || ""}-${
-                  row.Area || ""
-                }`;
+                currentArea = `${row.Division || ""}-${row.Province || ""}-${row.Area || ""
+                  }`;
               }
 
               const rowData = [
@@ -755,8 +776,8 @@ const SolarPVBilling: React.FC = () => {
         selectedCategory === "Entire CEB"
           ? "EntireCEB"
           : selectedCategory === "Area"
-          ? `${selectedCategory}_${selectedCategoryName}`
-          : `${selectedCategory}_${categoryValue}`;
+            ? `${selectedCategory}_${selectedCategoryName}`
+            : `${selectedCategory}_${categoryValue}`;
 
       link.setAttribute("href", url);
       link.setAttribute(
@@ -1633,16 +1654,16 @@ const SolarPVBilling: React.FC = () => {
         // Handle response data
         const responseData = result.data || result;
         let detailedDataArray = [];
-        
+
         if (Array.isArray(responseData)) {
           detailedDataArray = responseData;
         } else if (responseData && typeof responseData === 'object') {
           detailedDataArray = [responseData];
         }
-        
+
         // Filter out any null or undefined entries
         detailedDataArray = detailedDataArray.filter(item => item != null);
-        
+
         console.log("Processed detailed data:", detailedDataArray);
         setDetailedData(detailedDataArray);
         setReportVisible(true);
@@ -1694,16 +1715,16 @@ const SolarPVBilling: React.FC = () => {
         // Handle response data
         const responseData = result.data || result;
         let detailedDataArray = [];
-        
+
         if (Array.isArray(responseData)) {
           detailedDataArray = responseData;
         } else if (responseData && typeof responseData === 'object') {
           detailedDataArray = [responseData];
         }
-        
+
         // Filter out any null or undefined entries
         detailedDataArray = detailedDataArray.filter(item => item != null);
-        
+
         console.log("Processed detailed data:", detailedDataArray);
         setDetailedData(detailedDataArray);
         setReportVisible(true);
@@ -1769,19 +1790,19 @@ const SolarPVBilling: React.FC = () => {
 
         let ordinaryArray = [];
         let bulkArray = [];
-        
+
         if (Array.isArray(ordinaryResponseData)) {
           ordinaryArray = ordinaryResponseData;
         } else if (ordinaryResponseData && typeof ordinaryResponseData === 'object') {
           ordinaryArray = [ordinaryResponseData];
         }
-        
+
         if (Array.isArray(bulkResponseData)) {
           bulkArray = bulkResponseData;
         } else if (bulkResponseData && typeof bulkResponseData === 'object') {
           bulkArray = [bulkResponseData];
         }
-        
+
         // Filter out any null or undefined entries
         ordinaryArray = ordinaryArray.filter(item => item != null);
         bulkArray = bulkArray.filter(item => item != null);
@@ -1872,10 +1893,11 @@ const SolarPVBilling: React.FC = () => {
                   className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
                   required
                 >
-                  <option value="Area">Area</option>
-                  <option value="Province">Province</option>
-                  <option value="Region">Region</option>
-                  <option value="Entire CEB">Entire CEB</option>
+                  {allowedCategories.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
+                  ))}
                 </select>
               </div>
 
@@ -1911,13 +1933,22 @@ const SolarPVBilling: React.FC = () => {
                     </div>
                   ) : areaError ? (
                     <div className="text-red-500 text-xs py-2">{areaError}</div>
+                  ) : locked["Area"] ? (
+                    <select
+                      disabled
+                      value={locked["Area"].code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Area"].code}>
+                        {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                      </option>
+                    </select>
                   ) : (
                     <select
                       value={categoryValue}
                       onChange={(e) => {
                         const selectedAreaCode = e.target.value;
                         setCategoryValue(selectedAreaCode);
-                        // Find and store the area name
                         const selectedArea = areas.find(
                           (area) => area.AreaCode === selectedAreaCode
                         );
@@ -1973,6 +2004,16 @@ const SolarPVBilling: React.FC = () => {
                     <div className="text-red-500 text-xs py-2">
                       {provinceError}
                     </div>
+                  ) : locked["Province"] ? (
+                    <select
+                      disabled
+                      value={locked["Province"].code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Province"].code}>
+                        {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                      </option>
+                    </select>
                   ) : (
                     <select
                       value={categoryValue}
@@ -1983,10 +2024,7 @@ const SolarPVBilling: React.FC = () => {
                     >
                       <option value="">Select Province</option>
                       {provinces.map((province) => (
-                        <option
-                          key={province.ProvinceCode}
-                          value={province.ProvinceCode}
-                        >
+                        <option key={province.ProvinceCode} value={province.ProvinceCode}>
                           {formatProvinceOption(province)}
                         </option>
                       ))}
@@ -2028,6 +2066,14 @@ const SolarPVBilling: React.FC = () => {
                     <div className="text-red-500 text-xs py-2">
                       {divisionError}
                     </div>
+                  ) : locked["Region"] ? (
+                    <select
+                      disabled
+                      value={locked["Region"].code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                    </select>
                   ) : (
                     <select
                       value={categoryValue}
@@ -2038,10 +2084,7 @@ const SolarPVBilling: React.FC = () => {
                     >
                       <option value="">Select Region</option>
                       {divisions.map((division) => (
-                        <option
-                          key={division.RegionCode}
-                          value={division.RegionCode}
-                        >
+                        <option key={division.RegionCode} value={division.RegionCode}>
                           {formatDivisionOption(division)}
                         </option>
                       ))}
@@ -2053,9 +2096,8 @@ const SolarPVBilling: React.FC = () => {
               {/* Cycle Type Dropdown */}
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isCycleTypeDisabled() ? "text-gray-400" : maroon
-                  }`}
+                  className={`text-xs font-medium mb-1 ${isCycleTypeDisabled() ? "text-gray-400" : maroon
+                    }`}
                 >
                   Select Cycle Type:
                 </label>
@@ -2063,11 +2105,10 @@ const SolarPVBilling: React.FC = () => {
                   value={selectedCycleType}
                   onChange={handleCycleTypeChange}
                   className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
-                                        ${
-                                          isCycleTypeDisabled()
-                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                            : "border-gray-300"
-                                        }`}
+                                        ${isCycleTypeDisabled()
+                      ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      : "border-gray-300"
+                    }`}
                   required
                   disabled={isCycleTypeDisabled()}
                 >
@@ -2080,9 +2121,8 @@ const SolarPVBilling: React.FC = () => {
               {/* Month/Cycle Dropdown */}
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isMonthDisabled() ? "text-gray-400" : maroon
-                  }`}
+                  className={`text-xs font-medium mb-1 ${isMonthDisabled() ? "text-gray-400" : maroon
+                    }`}
                 >
                   Select Month:
                 </label>
@@ -2127,11 +2167,10 @@ const SolarPVBilling: React.FC = () => {
                       );
                     }}
                     className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
-                                            ${
-                                              isMonthDisabled()
-                                                ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                : "border-gray-300"
-                                            }`}
+                                            ${isMonthDisabled()
+                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                        : "border-gray-300"
+                      }`}
                     required
                     disabled={isMonthDisabled()}
                   >
@@ -2148,11 +2187,10 @@ const SolarPVBilling: React.FC = () => {
               {/* Report Type Dropdown */}
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isReportTypeDisabled()
+                  className={`text-xs font-medium mb-1 ${isReportTypeDisabled()
                       ? "text-gray-400" // light gray when disabled
                       : maroon
-                  }`}
+                    }`}
                 >
                   Select Type:
                 </label>
@@ -2160,11 +2198,10 @@ const SolarPVBilling: React.FC = () => {
                   value={reportType}
                   onChange={(e) => setReportType(e.target.value)}
                   className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
-                                ${
-                                  isReportTypeDisabled()
-                                    ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                    : "border-gray-300"
-                                }`}
+                                ${isReportTypeDisabled()
+                      ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      : "border-gray-300"
+                    }`}
                   required
                   disabled={isReportTypeDisabled()}
                 >
@@ -2185,9 +2222,8 @@ const SolarPVBilling: React.FC = () => {
               <button
                 type="submit"
                 className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow
-                            ${maroonGrad} text-white ${
-                  loading ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
-                }`}
+                            ${maroonGrad} text-white ${loading ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
+                  }`}
                 disabled={loading || isReportTypeDisabled() || !reportType}
               >
                 {loading ? (
@@ -2238,8 +2274,8 @@ const SolarPVBilling: React.FC = () => {
                 {selectedCategory === "Entire CEB"
                   ? "Entire CEB"
                   : selectedCategory === "Area"
-                  ? `${selectedCategory}: ${selectedCategoryName}`
-                  : `${selectedCategory}: ${categoryValue}`}{" "}
+                    ? `${selectedCategory}: ${selectedCategoryName}`
+                    : `${selectedCategory}: ${categoryValue}`}{" "}
                 |{selectedCycleType}: {selectedCycleDisplay} | Type:{" "}
                 {reportType}
               </p>
@@ -2257,7 +2293,7 @@ const SolarPVBilling: React.FC = () => {
               >
                 <FaPrint className="w-3 h-3" /> PDF
               </button>
-              
+
               <button
                 onClick={() => setReportVisible(false)}
                 className="px-4 py-1.5 bg-[#7A0000] hover:bg-[#A52A2A] text-xs rounded-md text-white flex items-center"

--- a/src/mainTopics/SolarInformation/SolarPVCapacityInformation.tsx
+++ b/src/mainTopics/SolarInformation/SolarPVCapacityInformation.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef, JSX } from "react";
 import { Download, Printer } from "lucide-react";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
     AreaCode: string;
@@ -70,6 +72,9 @@ const SolarPVCapacityInformation: React.FC = () => {
     const [pvCapacityData, setPvCapacityData] = useState<PVCapacityData[]>([]);
     const [uniqueNetTypes, setUniqueNetTypes] = useState<string[]>([]);
 
+    const { user } = useUser();
+    const { allowedCategories, locked } = useReportScope();
+
     const printRef = useRef<HTMLDivElement>(null);
 
     // Helper function for error handling
@@ -118,7 +123,7 @@ const SolarPVCapacityInformation: React.FC = () => {
     // Extract unique net types from data
     const extractUniqueNetTypes = (data: PVCapacityData[]): string[] => {
         const netTypes = [...new Set(data.map(item => item.NetType))];
-        
+
         // Define the desired order
         const orderPriority: { [key: string]: number } = {
             "Net Metering": 1,
@@ -127,12 +132,12 @@ const SolarPVCapacityInformation: React.FC = () => {
             "Net Plus Plus": 4,
             "Convert from Net Metering to Net Accounting": 5
         };
-        
+
         // Sort net types based on priority, unknown types go to the end
         return netTypes.sort((a, b) => {
             const priorityA = orderPriority[a] || 999;
             const priorityB = orderPriority[b] || 999;
-            
+
             if (priorityA !== priorityB) {
                 return priorityA - priorityB;
             }
@@ -164,7 +169,13 @@ const SolarPVCapacityInformation: React.FC = () => {
             setIsLoadingAreas(true);
             setAreaError(null);
             try {
-                const areaData = await fetchWithErrorHandling("/misapi/api/ordinary/areas");
+                let url = "/misapi/api/ordinary/areas";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                } else if (locked["Province"]?.code) {
+                    url += `?provCode=${locked["Province"].code}`;
+                }
+                const areaData = await fetchWithErrorHandling(url);
                 const sortedAreas = (areaData.data || []).sort((a: Area, b: Area) =>
                     a.AreaName.localeCompare(b.AreaName)
                 );
@@ -176,9 +187,8 @@ const SolarPVCapacityInformation: React.FC = () => {
                 setIsLoadingAreas(false);
             }
         };
-
         fetchAreas();
-    }, []);
+    }, [user.Level]);
 
     // Fetch provinces
     useEffect(() => {
@@ -186,12 +196,13 @@ const SolarPVCapacityInformation: React.FC = () => {
             setIsLoadingProvinces(true);
             setProvinceError(null);
             try {
-                const provinceData = await fetchWithErrorHandling(
-                    "/misapi/api/ordinary/province"
-                );
-                const sortedProvinces = (provinceData.data || []).sort(
-                    (a: Province, b: Province) =>
-                        a.ProvinceName.localeCompare(b.ProvinceName)
+                let url = "/misapi/api/ordinary/province";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                }
+                const provinceData = await fetchWithErrorHandling(url);
+                const sortedProvinces = (provinceData.data || []).sort((a: Province, b: Province) =>
+                    a.ProvinceName.localeCompare(b.ProvinceName)
                 );
                 setProvinces(sortedProvinces);
             } catch (err: any) {
@@ -201,9 +212,8 @@ const SolarPVCapacityInformation: React.FC = () => {
                 setIsLoadingProvinces(false);
             }
         };
-
         fetchProvinces();
-    }, []);
+    }, [user.Level]);
 
     // Fetch divisions
     useEffect(() => {
@@ -228,6 +238,15 @@ const SolarPVCapacityInformation: React.FC = () => {
 
         fetchDivisions();
     }, []);
+
+    useEffect(() => {
+        const key = selectedCategory === "Division" ? "Region" : selectedCategory;
+        const lock = locked[key as keyof typeof locked];
+        if (lock) {
+            setCategoryValue(lock.code);
+            setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+        }
+    }, [selectedCategory, locked]);
 
     // Fetch calendar months
     useEffect(() => {
@@ -302,7 +321,7 @@ const SolarPVCapacityInformation: React.FC = () => {
         const sortedData = sortDataHierarchically(pvCapacityData);
 
         const uniqueDivisions = [...new Set(sortedData.map(item => item.Division))];
-        
+
         const divisionGroups: { [key: string]: typeof sortedData } = {};
         const provinceGroups: { [key: string]: typeof sortedData } = {};
         const areaGroups: { [key: string]: typeof sortedData } = {};
@@ -351,14 +370,14 @@ const SolarPVCapacityInformation: React.FC = () => {
             } else {
                 row.push(label);
             }
-            
+
             // For Province Total (colspan=1), we need empty Province and Area columns
             // For Division Total (colspan=2), we need empty Area column
             if (colspan === 1) {
                 row.push(""); // Empty Province column
             }
             row.push(""); // Empty Area column
-            
+
             uniqueNetTypes.forEach(netType => {
                 row.push((netTypeTotals[netType]?.consumers || 0).toString());
                 row.push((netTypeTotals[netType]?.capacity || 0).toFixed(2));
@@ -374,11 +393,11 @@ const SolarPVCapacityInformation: React.FC = () => {
 
         uniqueDivisions.forEach((division) => {
             const provincesInDivision = Object.keys(provinceGroups).filter(pk => pk.startsWith(`${division}-`));
-            
+
             provincesInDivision.forEach((provinceKey) => {
                 const [] = provinceKey.split('-');
                 const areasInProvince = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
-                
+
                 areasInProvince.forEach((areaKey) => {
                     const items = areaGroups[areaKey];
                     const firstItem = items[0];
@@ -400,7 +419,7 @@ const SolarPVCapacityInformation: React.FC = () => {
 
                     const netTypeMap: { [key: string]: { consumers: number; capacity: number } } = {};
                     let areaTotal = { consumers: 0, capacity: 0 };
-                    
+
                     items.forEach((item) => {
                         netTypeMap[item.NetType] = {
                             consumers: item.NoOfConsumers,
@@ -416,14 +435,14 @@ const SolarPVCapacityInformation: React.FC = () => {
                         showProvince ? firstItem.Province : "",
                         firstItem.Area
                     ];
-                    
+
                     uniqueNetTypes.forEach(netType => {
                         row.push(netTypeMap[netType]?.consumers.toString() || "");
                         row.push(netTypeMap[netType]?.capacity.toFixed(2) || "");
                     });
                     row.push(areaTotal.consumers.toString());
                     row.push(areaTotal.capacity.toFixed(2));
-                    
+
                     rows.push(row);
                 });
 
@@ -495,7 +514,7 @@ const SolarPVCapacityInformation: React.FC = () => {
         // Generate the exact same table structure as displayed
         const sortedData = sortDataHierarchically(pvCapacityData);
         const uniqueDivisions = [...new Set(sortedData.map(item => item.Division))];
-        
+
         const divisionGroups: { [key: string]: typeof sortedData } = {};
         const provinceGroups: { [key: string]: typeof sortedData } = {};
         const areaGroups: { [key: string]: typeof sortedData } = {};
@@ -522,31 +541,31 @@ const SolarPVCapacityInformation: React.FC = () => {
         uniqueDivisions.forEach((division) => {
             let count = 0;
             const provincesInDiv = Object.keys(provinceGroups).filter(pk => pk.startsWith(`${division}-`));
-            
+
             provincesInDiv.forEach((provinceKey) => {
                 const areasInProv = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
                 count += areasInProv.length;
-                
+
                 if (areasInProv.length > 1) {
                     count += 1;
                 }
             });
-            
+
             if (provincesInDiv.length > 1) {
                 count += 1;
             }
-            
+
             divisionRowSpans[division] = count;
         });
 
         Object.keys(provinceGroups).forEach((provinceKey) => {
             const areasInProv = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
             let count = areasInProv.length;
-            
+
             if (areasInProv.length > 1) {
                 count += 1;
             }
-            
+
             provinceRowSpans[provinceKey] = count;
         });
 
@@ -573,19 +592,19 @@ const SolarPVCapacityInformation: React.FC = () => {
 
         const renderTotalRowHTML = (label: string, netTypeTotals: any, overallTotal: any, bgColor: string, colspan: number) => {
             let cells = `<td class="text-center font-bold" colspan="${colspan}">${label}</td>`;
-            
+
             uniqueNetTypes.forEach(netType => {
                 cells += `
                     <td class="text-right">${(netTypeTotals[netType]?.consumers || 0).toLocaleString()}</td>
                     <td class="text-right">${formatNumber(netTypeTotals[netType]?.capacity || 0)}</td>
                 `;
             });
-            
+
             cells += `
                 <td class="text-right">${overallTotal.consumers.toLocaleString()}</td>
                 <td class="text-right">${formatNumber(overallTotal.capacity)}</td>
             `;
-            
+
             return `<tr class="${bgColor}">${cells}</tr>`;
         };
 
@@ -597,11 +616,11 @@ const SolarPVCapacityInformation: React.FC = () => {
 
         uniqueDivisions.forEach((division) => {
             const provincesInDivision = Object.keys(provinceGroups).filter(pk => pk.startsWith(`${division}-`));
-            
+
             provincesInDivision.forEach((provinceKey) => {
                 const [] = provinceKey.split('-');
                 const areasInProvince = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
-                
+
                 areasInProvince.forEach((areaKey) => {
                     const items = areaGroups[areaKey];
                     const firstItem = items[0];
@@ -631,7 +650,7 @@ const SolarPVCapacityInformation: React.FC = () => {
 
                     const netTypeMap: { [key: string]: { consumers: number; capacity: number } } = {};
                     let areaTotal = { consumers: 0, capacity: 0 };
-                    
+
                     items.forEach((item) => {
                         netTypeMap[item.NetType] = {
                             consumers: item.NoOfConsumers,
@@ -643,31 +662,31 @@ const SolarPVCapacityInformation: React.FC = () => {
 
                     const rowClass = rowIndex % 2 === 0 ? 'row-even' : 'row-odd';
                     let row = `<tr class="${rowClass}">`;
-                    
+
                     if (showDivision) {
                         row += `<td class="font-medium" rowspan="${divisionRowSpans[divisionKey]}">${firstItem.Division}</td>`;
                     }
-                    
+
                     if (showProvince) {
                         row += `<td rowspan="${provinceRowSpans[provinceKeyForCheck]}">${firstItem.Province}</td>`;
                     }
-                    
+
                     if (showArea) {
                         row += `<td rowspan="${areaRowCounts[areaKeyForCheck]}">${firstItem.Area}</td>`;
                     }
-                    
+
                     uniqueNetTypes.forEach(netType => {
                         row += `
                             <td class="text-right">${netTypeMap[netType]?.consumers.toLocaleString() || ""}</td>
                             <td class="text-right">${netTypeMap[netType] ? formatNumber(netTypeMap[netType].capacity) : ""}</td>
                         `;
                     });
-                    
+
                     row += `
                         <td class="text-right font-bold">${areaTotal.consumers.toLocaleString()}</td>
                         <td class="text-right font-bold">${formatNumber(areaTotal.capacity)}</td>
                     </tr>`;
-                    
+
                     tableRows += row;
                     rowIndex++;
                 });
@@ -691,11 +710,11 @@ const SolarPVCapacityInformation: React.FC = () => {
                 <th rowspan="2">Division</th>
                 <th rowspan="2">Province</th>
                 <th rowspan="2">Area</th>`;
-        
+
         uniqueNetTypes.forEach(netType => {
             headerRow1 += `<th colspan="2">${netType}</th>`;
         });
-        
+
         headerRow1 += `<th colspan="2">Total</th></tr>`;
 
         let headerRow2 = '<tr>';
@@ -816,7 +835,7 @@ const SolarPVCapacityInformation: React.FC = () => {
         const sortedData = sortDataHierarchically(pvCapacityData);
 
         const uniqueDivisions = [...new Set(sortedData.map(item => item.Division))];
-        
+
         const divisionGroups: { [key: string]: typeof sortedData } = {};
         const provinceGroups: { [key: string]: typeof sortedData } = {};
         const areaGroups: { [key: string]: typeof sortedData } = {};
@@ -843,31 +862,31 @@ const SolarPVCapacityInformation: React.FC = () => {
         uniqueDivisions.forEach((division) => {
             let count = 0;
             const provincesInDiv = Object.keys(provinceGroups).filter(pk => pk.startsWith(`${division}-`));
-            
+
             provincesInDiv.forEach((provinceKey) => {
                 const areasInProv = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
                 count += areasInProv.length;
-                
+
                 if (areasInProv.length > 1) {
                     count += 1;
                 }
             });
-            
+
             if (provincesInDiv.length > 1) {
                 count += 1;
             }
-            
+
             divisionRowSpans[division] = count;
         });
 
         Object.keys(provinceGroups).forEach((provinceKey) => {
             const areasInProv = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
             let count = areasInProv.length;
-            
+
             if (areasInProv.length > 1) {
                 count += 1;
             }
-            
+
             provinceRowSpans[provinceKey] = count;
         });
 
@@ -926,11 +945,11 @@ const SolarPVCapacityInformation: React.FC = () => {
 
         uniqueDivisions.forEach((division) => {
             const provincesInDivision = Object.keys(provinceGroups).filter(pk => pk.startsWith(`${division}-`));
-            
+
             provincesInDivision.forEach((provinceKey) => {
                 const [] = provinceKey.split('-');
                 const areasInProvince = Object.keys(areaGroups).filter(ak => ak.startsWith(`${provinceKey}-`));
-                
+
                 areasInProvince.forEach((areaKey) => {
                     const items = areaGroups[areaKey];
                     const firstItem = items[0];
@@ -960,7 +979,7 @@ const SolarPVCapacityInformation: React.FC = () => {
 
                     const netTypeMap: { [key: string]: { consumers: number; capacity: number } } = {};
                     let areaTotal = { consumers: 0, capacity: 0 };
-                    
+
                     items.forEach((item) => {
                         netTypeMap[item.NetType] = {
                             consumers: item.NoOfConsumers,
@@ -980,7 +999,7 @@ const SolarPVCapacityInformation: React.FC = () => {
                                     {firstItem.Division}
                                 </td>
                             ) : null}
-                            
+
                             {showProvince ? (
                                 <td
                                     className="border border-gray-300 px-2 py-1 align-top"
@@ -989,7 +1008,7 @@ const SolarPVCapacityInformation: React.FC = () => {
                                     {firstItem.Province}
                                 </td>
                             ) : null}
-                            
+
                             {showArea ? (
                                 <td
                                     className="border border-gray-300 px-2 py-1 align-top"
@@ -998,7 +1017,7 @@ const SolarPVCapacityInformation: React.FC = () => {
                                     {firstItem.Area}
                                 </td>
                             ) : null}
-                            
+
                             {uniqueNetTypes.map(netType => (
                                 <React.Fragment key={netType}>
                                     <td className="border border-gray-300 px-2 py-1 text-right">
@@ -1009,7 +1028,7 @@ const SolarPVCapacityInformation: React.FC = () => {
                                     </td>
                                 </React.Fragment>
                             ))}
-                            
+
                             <td className="border border-gray-300 px-2 py-1 text-right font-semibold">
                                 {areaTotal.consumers.toLocaleString()}
                             </td>
@@ -1328,10 +1347,11 @@ const SolarPVCapacityInformation: React.FC = () => {
                                     required
                                     disabled={isCategoryDisabled()}
                                 >
-                                    <option value="Area">Area</option>
-                                    <option value="Province">Province</option>
-                                    <option value="Division">Division</option>
-                                    <option value="Entire CEB">Entire CEB</option>
+                                    {allowedCategories.map((cat) => (
+                                        <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                                            {cat === "Region" ? "Division" : cat}
+                                        </option>
+                                    ))}
                                 </select>
                             </div>
 
@@ -1370,6 +1390,16 @@ const SolarPVCapacityInformation: React.FC = () => {
                                         </div>
                                     ) : areaError ? (
                                         <div className="text-red-500 text-xs py-2">{areaError}</div>
+                                    ) : locked["Area"] ? (
+                                        <select
+                                            disabled
+                                            value={locked["Area"].code}
+                                            className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        >
+                                            <option value={locked["Area"].code}>
+                                                {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                                            </option>
+                                        </select>
                                     ) : (
                                         <select
                                             value={categoryValue}
@@ -1439,24 +1469,32 @@ const SolarPVCapacityInformation: React.FC = () => {
                                         <div className="text-red-500 text-xs py-2">
                                             {provinceError}
                                         </div>
+                                    ) : locked["Province"] ? (
+                                        <select
+                                            disabled
+                                            value={locked["Province"].code}
+                                            className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        >
+                                            <option value={locked["Province"].code}>
+                                                {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                                            </option>
+                                        </select>
                                     ) : (
                                         <select
                                             value={categoryValue}
                                             onChange={(e) => setCategoryValue(e.target.value)}
                                             className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
-                        ${isCategoryValueDisabled()
+                                            ${isCategoryValueDisabled()
                                                     ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                                                     : "border-gray-300"
                                                 }`}
+
                                             required
                                             disabled={isCategoryValueDisabled()}
                                         >
                                             <option value="">Select Province</option>
                                             {provinces.map((province) => (
-                                                <option
-                                                    key={province.ProvinceCode}
-                                                    value={province.ProvinceCode}
-                                                >
+                                                <option key={province.ProvinceCode} value={province.ProvinceCode}>
                                                     {formatProvinceOption(province)}
                                                 </option>
                                             ))}
@@ -1502,6 +1540,14 @@ const SolarPVCapacityInformation: React.FC = () => {
                                         <div className="text-red-500 text-xs py-2">
                                             {divisionError}
                                         </div>
+                                    ) : locked["Region"] ? (
+                                        <select
+                                            disabled
+                                            value={locked["Region"].code}
+                                            className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        >
+                                            <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                                        </select>
                                     ) : (
                                         <select
                                             value={categoryValue}
@@ -1516,10 +1562,7 @@ const SolarPVCapacityInformation: React.FC = () => {
                                         >
                                             <option value="">Select Division</option>
                                             {divisions.map((division) => (
-                                                <option
-                                                    key={division.RegionCode}
-                                                    value={division.RegionCode}
-                                                >
+                                                <option key={division.RegionCode} value={division.RegionCode}>
                                                     {formatDivisionOption(division)}
                                                 </option>
                                             ))}

--- a/src/mainTopics/SolarInformation/SolarPaymentBulk.tsx
+++ b/src/mainTopics/SolarInformation/SolarPaymentBulk.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef, JSX } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
     AreaCode: string;
@@ -85,6 +87,9 @@ const SolarPaymentBulk: React.FC = () => {
     // Report data
     const [reportData, setReportData] = useState<BulkPaymentData[]>([]);
 
+    const { user } = useUser();
+    const { allowedCategories, locked } = useReportScope();
+
     const printRef = useRef<HTMLDivElement>(null);
 
     // Helper function for error handling
@@ -149,16 +154,16 @@ const SolarPaymentBulk: React.FC = () => {
             setBillCycleError(null);
             try {
                 const response = await fetchWithErrorHandling("/misapi/api/bulk/netmtcons/billcycle/max");
-                
+
                 console.log("Bill cycle response:", response); // Debug log
-                
+
                 // The response structure is: { data: { BillCycles: [...], MaxBillCycle: "445" } }
                 const billCyclesArray = response?.data?.BillCycles;
                 const maxBillCycle = response?.data?.MaxBillCycle;
-                
+
                 if (billCyclesArray && Array.isArray(billCyclesArray) && maxBillCycle) {
                     const maxCycleNum = parseInt(maxBillCycle);
-                    
+
                     // Map bill cycles to options with format "445 - Sep 25"
                     const options: BillCycleOption[] = billCyclesArray.map((cycle: string, index: number) => {
                         const cycleNumber = maxCycleNum - index;
@@ -167,10 +172,10 @@ const SolarPaymentBulk: React.FC = () => {
                             code: cycleNumber.toString(), // "445"
                         };
                     });
-                    
+
                     console.log("Parsed bill cycle options:", options); // Debug log
                     setBillCycleOptions(options);
-                    
+
                     if (options.length === 0) {
                         setBillCycleError("No bill cycles available");
                     }
@@ -197,7 +202,13 @@ const SolarPaymentBulk: React.FC = () => {
             setIsLoadingAreas(true);
             setAreaError(null);
             try {
-                const areaData = await fetchWithErrorHandling("/misapi/api/bulk/areas");
+                let url = "/misapi/api/bulk/areas";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                } else if (locked["Province"]?.code) {
+                    url += `?provCode=${locked["Province"].code}`;
+                }
+                const areaData = await fetchWithErrorHandling(url);
                 setAreas(areaData.data || []);
             } catch (err: any) {
                 console.error("Error fetching areas:", err);
@@ -210,7 +221,7 @@ const SolarPaymentBulk: React.FC = () => {
         };
 
         fetchAreas();
-    }, []);
+    }, [user.Level]);
 
     // Fetch provinces
     useEffect(() => {
@@ -218,9 +229,11 @@ const SolarPaymentBulk: React.FC = () => {
             setIsLoadingProvinces(true);
             setProvinceError(null);
             try {
-                const provinceData = await fetchWithErrorHandling(
-                    "/misapi/api/bulk/province"
-                );
+                let url = "/misapi/api/bulk/province";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                }
+                const provinceData = await fetchWithErrorHandling(url);
                 setProvinces(provinceData.data || []);
             } catch (err: any) {
                 console.error("Error fetching provinces:", err);
@@ -233,7 +246,7 @@ const SolarPaymentBulk: React.FC = () => {
         };
 
         fetchProvinces();
-    }, []);
+    }, [user.Level]);
 
     // Fetch divisions
     useEffect(() => {
@@ -257,6 +270,16 @@ const SolarPaymentBulk: React.FC = () => {
 
         fetchDivisions();
     }, []);
+
+
+    useEffect(() => {
+        const key = reportCategory === "Division" ? "Region" : reportCategory;
+        const lock = locked[key as keyof typeof locked];
+        if (lock) {
+            setCategoryValue(lock.code);
+            setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+        }
+    }, [reportCategory, locked]);
 
     // Reset category value when report category changes
     useEffect(() => {
@@ -953,7 +976,7 @@ const SolarPaymentBulk: React.FC = () => {
                                 <td className="px-2 py-1.5 border border-gray-300 whitespace-nowrap">
                                     {row.AgreementDate}
                                 </td>
-                                
+
                             </tr>
                         );
                         rowIndex++;
@@ -974,7 +997,7 @@ const SolarPaymentBulk: React.FC = () => {
                                 <td className="px-2 py-1.5 border border-gray-300" colSpan={1}>
                                     Area Total
                                 </td>
-                                
+
                                 <td className="px-2 py-1.5 text-right border border-gray-300">
                                     {totals.count}
                                 </td>
@@ -1009,7 +1032,7 @@ const SolarPaymentBulk: React.FC = () => {
                             <td className="px-2 py-1.5 border border-gray-300" colSpan={2}>
                                 Province Total
                             </td>
-                            
+
                             <td className="px-2 py-1.5 text-right border border-gray-300">
                                 {totals.count}
                             </td>
@@ -1044,7 +1067,7 @@ const SolarPaymentBulk: React.FC = () => {
                         <td className="px-2 py-1.5 border border-gray-300" colSpan={3}>
                             Division Total
                         </td>
-                        
+
                         <td className="px-2 py-1.5 text-right border border-gray-300">
                             {totals.count}
                         </td>
@@ -1088,7 +1111,7 @@ const SolarPaymentBulk: React.FC = () => {
                         <th className="px-2 py-2 text-left border border-gray-300 font-semibold">Branch Code</th>
                         <th className="px-2 py-2 text-left border border-gray-300 font-semibold">Bank Account Number</th>
                         <th className="px-2 py-2 text-left border border-gray-300 font-semibold">Agreement Date</th>
-                        
+
                     </tr>
                 </thead>
                 <tbody>
@@ -1146,27 +1169,26 @@ const SolarPaymentBulk: React.FC = () => {
                             {/* Select Report Category Dropdown */}
                             <div className="flex flex-col">
                                 <label
-                                    className={`text-xs font-medium mb-1 ${
-                                        !billCycle ? "text-gray-400" : maroon
-                                    }`}
+                                    className={`text-xs font-medium mb-1 ${!billCycle ? "text-gray-400" : maroon
+                                        }`}
                                 >
                                     Select Report Category:
                                 </label>
                                 <select
                                     value={reportCategory}
                                     onChange={(e) => setReportCategory(e.target.value)}
-                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                        !billCycle
-                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                            : "border-gray-300"
-                                    }`}
+                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${!billCycle
+                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        : "border-gray-300"
+                                        }`}
                                     disabled={!billCycle}
                                     required
                                 >
-                                    <option value="Area">Area</option>
-                                    <option value="Province">Province</option>
-                                    <option value="Division">Division</option>
-                                    <option value="Entire CEB">Entire CEB</option>
+                                    {allowedCategories.map((cat) => (
+                                        <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                                            {cat === "Region" ? "Division" : cat}
+                                        </option>
+                                    ))}
                                 </select>
                             </div>
 
@@ -1174,15 +1196,24 @@ const SolarPaymentBulk: React.FC = () => {
                             {reportCategory !== "Entire CEB" && (
                                 <div className="flex flex-col">
                                     <label
-                                        className={`text-xs font-medium mb-1 ${
-                                            isCategoryValueDisabled() ? "text-gray-400" : maroon
-                                        }`}
+                                        className={`text-xs font-medium mb-1 ${isCategoryValueDisabled() ? "text-gray-400" : maroon
+                                            }`}
                                     >
                                         Select {reportCategory}:
                                     </label>
                                     {reportCategory === "Area" && (
                                         <>
-                                            {isLoadingAreas ? (
+                                            {locked["Area"] ? (
+                                                <select
+                                                    disabled
+                                                    value={locked["Area"].code}
+                                                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                >
+                                                    <option value={locked["Area"].code}>
+                                                        {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                                                    </option>
+                                                </select>
+                                            ) : isLoadingAreas ? (
                                                 <div className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md bg-gray-50 text-gray-500">
                                                     Loading areas...
                                                 </div>
@@ -1194,11 +1225,10 @@ const SolarPaymentBulk: React.FC = () => {
                                                 <select
                                                     value={categoryValue}
                                                     onChange={(e) => setCategoryValue(e.target.value)}
-                                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                                        isCategoryValueDisabled()
-                                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                            : "border-gray-300"
-                                                    }`}
+                                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
+                                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                        : "border-gray-300"
+                                                        }`}
                                                     required
                                                     disabled={isCategoryValueDisabled()}
                                                 >
@@ -1214,7 +1244,17 @@ const SolarPaymentBulk: React.FC = () => {
                                     )}
                                     {reportCategory === "Province" && (
                                         <>
-                                            {isLoadingProvinces ? (
+                                            {locked["Province"] ? (
+                                                <select
+                                                    disabled
+                                                    value={locked["Province"].code}
+                                                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                >
+                                                    <option value={locked["Province"].code}>
+                                                        {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                                                    </option>
+                                                </select>
+                                            ) : isLoadingProvinces ? (
                                                 <div className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md bg-gray-50 text-gray-500">
                                                     Loading provinces...
                                                 </div>
@@ -1226,29 +1266,25 @@ const SolarPaymentBulk: React.FC = () => {
                                                 <select
                                                     value={categoryValue}
                                                     onChange={(e) => {
-                                                const selectedProvinceCode = e.target.value;
-                                                setCategoryValue(selectedProvinceCode);
-                                                const selectedProvince = provinces.find(
-                                                    (province) => province.ProvinceCode === selectedProvinceCode
-                                                );
-                                                setSelectedCategoryName(
-                                                    selectedProvince ? selectedProvince.ProvinceName : ""
-                                                );
-                                            }}
-                                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                                        isCategoryValueDisabled()
-                                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                            : "border-gray-300"
-                                                    }`}
+                                                        const selectedProvinceCode = e.target.value;
+                                                        setCategoryValue(selectedProvinceCode);
+                                                        const selectedProvince = provinces.find(
+                                                            (province) => province.ProvinceCode === selectedProvinceCode
+                                                        );
+                                                        setSelectedCategoryName(
+                                                            selectedProvince ? selectedProvince.ProvinceName : ""
+                                                        );
+                                                    }}
+                                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
+                                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                        : "border-gray-300"
+                                                        }`}
                                                     required
                                                     disabled={isCategoryValueDisabled()}
                                                 >
                                                     <option value="">Select Province</option>
                                                     {provinces.map((province) => (
-                                                        <option
-                                                            key={province.ProvinceCode}
-                                                            value={province.ProvinceCode}
-                                                        >
+                                                        <option key={province.ProvinceCode} value={province.ProvinceCode}>
                                                             {province.ProvinceCode} - {province.ProvinceName}
                                                         </option>
                                                     ))}
@@ -1258,7 +1294,15 @@ const SolarPaymentBulk: React.FC = () => {
                                     )}
                                     {reportCategory === "Division" && (
                                         <>
-                                            {isLoadingDivisions ? (
+                                            {locked["Region"] ? (
+                                                <select
+                                                    disabled
+                                                    value={locked["Region"].code}
+                                                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                >
+                                                    <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                                                </select>
+                                            ) : isLoadingDivisions ? (
                                                 <div className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md bg-gray-50 text-gray-500">
                                                     Loading divisions...
                                                 </div>
@@ -1270,24 +1314,20 @@ const SolarPaymentBulk: React.FC = () => {
                                                 <select
                                                     value={categoryValue}
                                                     onChange={(e) => {
-                                                const selectedDivisionCode = e.target.value;
-                                                setCategoryValue(selectedDivisionCode);
-                                                setSelectedCategoryName(selectedDivisionCode); // Division uses code as name
-                                            }}
-                                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                                        isCategoryValueDisabled()
-                                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                                            : "border-gray-300"
-                                                    }`}
+                                                        const selectedDivisionCode = e.target.value;
+                                                        setCategoryValue(selectedDivisionCode);
+                                                        setSelectedCategoryName(selectedDivisionCode);
+                                                    }}
+                                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled()
+                                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                                        : "border-gray-300"
+                                                        }`}
                                                     required
                                                     disabled={isCategoryValueDisabled()}
                                                 >
                                                     <option value="">Select Division</option>
                                                     {divisions.map((division) => (
-                                                        <option
-                                                            key={division.RegionCode}
-                                                            value={division.RegionCode}
-                                                        >
+                                                        <option key={division.RegionCode} value={division.RegionCode}>
                                                             {formatDivisionOption(division)}
                                                         </option>
                                                     ))}
@@ -1311,20 +1351,18 @@ const SolarPaymentBulk: React.FC = () => {
                             {/* Select Net Type Dropdown */}
                             <div className="flex flex-col">
                                 <label
-                                    className={`text-xs font-medium mb-1 ${
-                                        isNetTypeDisabled() ? "text-gray-400" : maroon
-                                    }`}
+                                    className={`text-xs font-medium mb-1 ${isNetTypeDisabled() ? "text-gray-400" : maroon
+                                        }`}
                                 >
                                     Select Net Type:
                                 </label>
                                 <select
                                     value={netType}
                                     onChange={(e) => setNetType(e.target.value)}
-                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                                        isNetTypeDisabled()
-                                            ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                            : "border-gray-300"
-                                    }`}
+                                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isNetTypeDisabled()
+                                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        : "border-gray-300"
+                                        }`}
                                     required
                                     disabled={isNetTypeDisabled()}
                                 >
@@ -1344,11 +1382,10 @@ const SolarPaymentBulk: React.FC = () => {
                         <div className="w-full mt-6 flex justify-end">
                             <button
                                 type="submit"
-                                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${
-                                    loading || !canSubmit()
-                                        ? "opacity-70 cursor-not-allowed"
-                                        : "hover:opacity-90"
-                                }`}
+                                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${loading || !canSubmit()
+                                    ? "opacity-70 cursor-not-allowed"
+                                    : "hover:opacity-90"
+                                    }`}
                                 disabled={loading || !canSubmit()}
                             >
                                 {loading ? (

--- a/src/mainTopics/SolarInformation/SolarPaymentRetail.tsx
+++ b/src/mainTopics/SolarInformation/SolarPaymentRetail.tsx
@@ -1,347 +1,369 @@
 import React, { useState, useEffect, useRef, JSX } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
-	AreaCode: string;
-	AreaName: string;
-	ErrorMessage?: string | null;
+    AreaCode: string;
+    AreaName: string;
+    ErrorMessage?: string | null;
 }
 
 interface Province {
-	ProvinceCode: string;
-	ProvinceName: string;
-	ErrorMessage?: string | null;
+    ProvinceCode: string;
+    ProvinceName: string;
+    ErrorMessage?: string | null;
 }
 
 interface Division {
-	RegionCode: string;
-	ErrorMessage?: string | null;
+    RegionCode: string;
+    ErrorMessage?: string | null;
 }
 
 interface BillCycleOption {
-	display: string;
-	code: string;
+    display: string;
+    code: string;
 }
 
 interface DetailedRetailPayment {
-	Division: string;
-	Province: string;
-	Area: string;
-	CustomerName: string;
-	AccountNumber: string;
-	PanelCapacity: number;
-	EnergyExported: number;
-	EnergyImported: number;
-	Tariff: string;
-	BFUnits: number;
-	UnitsInBill: number;
-	Period: number;
-	KwhCharge: number;
-	FixedCharge: number;
-	FuelCharge: number;
-	CFUnits: number;
-	Rate: number;
-	UnitSale: number;
-	KwhSales: number;
-	BankCode: string;
-	BranchCode: string;
-	BankAccountNumber: string;
-	AgreementDate: string;
-	ErrorMessage?: string;
+    Division: string;
+    Province: string;
+    Area: string;
+    CustomerName: string;
+    AccountNumber: string;
+    PanelCapacity: number;
+    EnergyExported: number;
+    EnergyImported: number;
+    Tariff: string;
+    BFUnits: number;
+    UnitsInBill: number;
+    Period: number;
+    KwhCharge: number;
+    FixedCharge: number;
+    FuelCharge: number;
+    CFUnits: number;
+    Rate: number;
+    UnitSale: number;
+    KwhSales: number;
+    BankCode: string;
+    BranchCode: string;
+    BankAccountNumber: string;
+    AgreementDate: string;
+    ErrorMessage?: string;
 }
 
 interface SummaryRetailPayment {
-	NetType: string;
-	NoOfAccounts: number;
-	EnergyExported: number;
-	EnergyImported: number;
-	UnitSaleKwh: number;
-	UnitSaleRs: number;
-	KwhPayableBalance: number;
-	ErrorMessage?: string;
+    NetType: string;
+    NoOfAccounts: number;
+    EnergyExported: number;
+    EnergyImported: number;
+    UnitSaleKwh: number;
+    UnitSaleRs: number;
+    KwhPayableBalance: number;
+    ErrorMessage?: string;
 }
 
 const SolarPaymentRetail: React.FC = () => {
-	const maroon = "text-[#7A0000]";
-	const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
+    const maroon = "text-[#7A0000]";
+    const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
 
-	const [selectedCycleType, setSelectedCycleType] = useState<string>("");
-	const [cycleValue, setCycleValue] = useState<string>("");
-	const [reportType, setReportType] = useState<string>("");
-	const [selectedCategory, setSelectedCategory] = useState<string>("Area");
-	const [categoryValue, setCategoryValue] = useState<string>("");
-	const [netType, setNetType] = useState<string>("");
-	const [loading, setLoading] = useState(false);
+    const [selectedCycleType, setSelectedCycleType] = useState<string>("");
+    const [cycleValue, setCycleValue] = useState<string>("");
+    const [reportType, setReportType] = useState<string>("");
+    const [selectedCategory, setSelectedCategory] = useState<string>("Area");
+    const [categoryValue, setCategoryValue] = useState<string>("");
+    const [netType, setNetType] = useState<string>("");
+    const [loading, setLoading] = useState(false);
 
-	// Data states
-	const [areas, setAreas] = useState<Area[]>([]);
-	const [provinces, setProvinces] = useState<Province[]>([]);
-	const [divisions, setDivisions] = useState<Division[]>([]);
-	const [cycleOptions, setCycleOptions] = useState<BillCycleOption[]>([]);
+    // Data states
+    const [areas, setAreas] = useState<Area[]>([]);
+    const [provinces, setProvinces] = useState<Province[]>([]);
+    const [divisions, setDivisions] = useState<Division[]>([]);
+    const [cycleOptions, setCycleOptions] = useState<BillCycleOption[]>([]);
 
-	// Loading states
-	const [isLoadingAreas, setIsLoadingAreas] = useState(false);
-	const [isLoadingProvinces, setIsLoadingProvinces] = useState(false);
-	const [isLoadingDivisions, setIsLoadingDivisions] = useState(false);
-	const [isLoadingCycles, setIsLoadingCycles] = useState(false);
+    // Loading states
+    const [isLoadingAreas, setIsLoadingAreas] = useState(false);
+    const [isLoadingProvinces, setIsLoadingProvinces] = useState(false);
+    const [isLoadingDivisions, setIsLoadingDivisions] = useState(false);
+    const [isLoadingCycles, setIsLoadingCycles] = useState(false);
 
-	// Error states
-	const [areaError, setAreaError] = useState<string | null>(null);
-	const [provinceError, setProvinceError] = useState<string | null>(null);
-	const [divisionError, setDivisionError] = useState<string | null>(null);
-	const [cycleError, setCycleError] = useState<string | null>(null);
-	const [reportError, setReportError] = useState<string | null>(null);
+    // Error states
+    const [areaError, setAreaError] = useState<string | null>(null);
+    const [provinceError, setProvinceError] = useState<string | null>(null);
+    const [divisionError, setDivisionError] = useState<string | null>(null);
+    const [cycleError, setCycleError] = useState<string | null>(null);
+    const [reportError, setReportError] = useState<string | null>(null);
 
-	// Display states
-	const [selectedCategoryName, setSelectedCategoryName] = useState<string>("");
-	const [selectedCycleDisplay, setSelectedCycleDisplay] = useState<string>("");
-	const [reportVisible, setReportVisible] = useState(false);
+    // Display states
+    const [selectedCategoryName, setSelectedCategoryName] = useState<string>("");
+    const [selectedCycleDisplay, setSelectedCycleDisplay] = useState<string>("");
+    const [reportVisible, setReportVisible] = useState(false);
 
-	// Report data
-	const [detailedData, setDetailedData] = useState<DetailedRetailPayment[]>(
-		[]
-	);
-	const [ordinarySummaryData, setOrdinarySummaryData] = useState<
-		SummaryRetailPayment[]
-	>([]);
-	const [bulkSummaryData, setBulkSummaryData] = useState<
-		SummaryRetailPayment[]
-	>([]);
+    // Report data
+    const [detailedData, setDetailedData] = useState<DetailedRetailPayment[]>(
+        []
+    );
+    const [ordinarySummaryData, setOrdinarySummaryData] = useState<
+        SummaryRetailPayment[]
+    >([]);
+    const [bulkSummaryData, setBulkSummaryData] = useState<
+        SummaryRetailPayment[]
+    >([]);
 
-	const printRef = useRef<HTMLDivElement>(null);
+    const { user } = useUser();
+    const { allowedCategories, locked } = useReportScope();
 
-	// Helper function for error handling
-	const fetchWithErrorHandling = async (url: string) => {
-		try {
-			const response = await fetch(url, {
-				headers: {
-					Accept: "application/json",
-				},
-			});
+    const printRef = useRef<HTMLDivElement>(null);
 
-			if (!response.ok) {
-				let errorMsg = `HTTP error! status: ${response.status}`;
-				try {
-					const errorData = await response.json();
-					if (errorData.errorMessage) {
-						errorMsg = errorData.errorMessage;
-					}
-				} catch (e) {
-					errorMsg = response.statusText;
-				}
-				throw new Error(errorMsg);
-			}
+    // Helper function for error handling
+    const fetchWithErrorHandling = async (url: string) => {
+        try {
+            const response = await fetch(url, {
+                headers: {
+                    Accept: "application/json",
+                },
+            });
 
-			const contentType = response.headers.get("content-type");
-			if (!contentType || !contentType.includes("application/json")) {
-				throw new Error(`Expected JSON response but got ${contentType}`);
-			}
+            if (!response.ok) {
+                let errorMsg = `HTTP error! status: ${response.status}`;
+                try {
+                    const errorData = await response.json();
+                    if (errorData.errorMessage) {
+                        errorMsg = errorData.errorMessage;
+                    }
+                } catch (e) {
+                    errorMsg = response.statusText;
+                }
+                throw new Error(errorMsg);
+            }
 
-			return await response.json();
-		} catch (error) {
-			console.error(`Error fetching ${url}:`, error);
-			throw error;
-		}
-	};
+            const contentType = response.headers.get("content-type");
+            if (!contentType || !contentType.includes("application/json")) {
+                throw new Error(`Expected JSON response but got ${contentType}`);
+            }
 
-	// Generate cycle options
-	const generateCycleOptions = (
-		cycles: string[],
-		maxCycle: string,
-		cycleType: string
-	): BillCycleOption[] => {
-		const maxCycleNum = parseInt(maxCycle);
-		return cycles.map((cycle, index) => ({
-			display:
-				cycleType === "Calculation Cycle"
-					? cycle
-					: `${(maxCycleNum - index).toString()} - ${cycle}`,
-			code: (maxCycleNum - index).toString(),
-		}));
-	};
+            return await response.json();
+        } catch (error) {
+            console.error(`Error fetching ${url}:`, error);
+            throw error;
+        }
+    };
 
-	// Sort data alphabetically
-	const sortDataAlphabetically = (
-		data: DetailedRetailPayment[]
-	): DetailedRetailPayment[] => {
-		return [...data].sort((a, b) => {
-			if (a.Division < b.Division) return -1;
-			if (a.Division > b.Division) return 1;
-			if (a.Province < b.Province) return -1;
-			if (a.Province > b.Province) return 1;
-			if (a.Area < b.Area) return -1;
-			if (a.Area > b.Area) return 1;
-			return 0;
-		});
-	};
+    // Generate cycle options
+    const generateCycleOptions = (
+        cycles: string[],
+        maxCycle: string,
+        cycleType: string
+    ): BillCycleOption[] => {
+        const maxCycleNum = parseInt(maxCycle);
+        return cycles.map((cycle, index) => ({
+            display:
+                cycleType === "Calculation Cycle"
+                    ? cycle
+                    : `${(maxCycleNum - index).toString()} - ${cycle}`,
+            code: (maxCycleNum - index).toString(),
+        }));
+    };
 
-	// Fetch areas
-	useEffect(() => {
-		const fetchAreas = async () => {
-			setIsLoadingAreas(true);
-			setAreaError(null);
-			try {
-				const areaData = await fetchWithErrorHandling("/misapi/api/ordinary/areas");
-				const sortedAreas = (areaData.data || []).sort((a: Area, b: Area) =>
-					a.AreaName.localeCompare(b.AreaName)
-				);
-				setAreas(sortedAreas);
-			} catch (err: any) {
-				console.error("Error fetching areas:", err);
-				setAreaError(
-					err.message || "Failed to load areas. Please try again later."
-				);
-			} finally {
-				setIsLoadingAreas(false);
-			}
-		};
+    // Sort data alphabetically
+    const sortDataAlphabetically = (
+        data: DetailedRetailPayment[]
+    ): DetailedRetailPayment[] => {
+        return [...data].sort((a, b) => {
+            if (a.Division < b.Division) return -1;
+            if (a.Division > b.Division) return 1;
+            if (a.Province < b.Province) return -1;
+            if (a.Province > b.Province) return 1;
+            if (a.Area < b.Area) return -1;
+            if (a.Area > b.Area) return 1;
+            return 0;
+        });
+    };
 
-		fetchAreas();
-	}, []);
+    // Fetch areas
+    useEffect(() => {
+        const fetchAreas = async () => {
+            setIsLoadingAreas(true);
+            setAreaError(null);
+            try {
+                let url = "/misapi/api/ordinary/areas";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                } else if (locked["Province"]?.code) {
+                    url += `?provCode=${locked["Province"].code}`;
+                }
+                const areaData = await fetchWithErrorHandling(url);
+                const sortedAreas = (areaData.data || []).sort((a: Area, b: Area) =>
+                    a.AreaName.localeCompare(b.AreaName)
+                );
+                setAreas(sortedAreas);
+            } catch (err: any) {
+                console.error("Error fetching areas:", err);
+                setAreaError(
+                    err.message || "Failed to load areas. Please try again later."
+                );
+            } finally {
+                setIsLoadingAreas(false);
+            }
+        };
 
-	// Fetch provinces
-	useEffect(() => {
-		const fetchProvinces = async () => {
-			setIsLoadingProvinces(true);
-			setProvinceError(null);
-			try {
-				const provinceData = await fetchWithErrorHandling(
-					"/misapi/api/ordinary/province"
-				);
-				const sortedProvinces = (provinceData.data || []).sort(
-					(a: Province, b: Province) =>
-						a.ProvinceName.localeCompare(b.ProvinceName)
-				);
-				setProvinces(sortedProvinces);
-			} catch (err: any) {
-				console.error("Error fetching provinces:", err);
-				setProvinceError(
-					err.message ||
-						"Failed to load provinces. Please try again later."
-				);
-			} finally {
-				setIsLoadingProvinces(false);
-			}
-		};
+        fetchAreas();
+    }, [user.Level]);
 
-		fetchProvinces();
-	}, []);
+    // Fetch provinces
+    useEffect(() => {
+        const fetchProvinces = async () => {
+            setIsLoadingProvinces(true);
+            setProvinceError(null);
+            try {
+                let url = "/misapi/api/ordinary/province";
+                if (locked["Region"]?.code) {
+                    url += `?regionCode=${locked["Region"].code}`;
+                }
+                const provinceData = await fetchWithErrorHandling(url);
+                const sortedProvinces = (provinceData.data || []).sort(
+                    (a: Province, b: Province) =>
+                        a.ProvinceName.localeCompare(b.ProvinceName)
+                );
+                setProvinces(sortedProvinces);
+            } catch (err: any) {
+                console.error("Error fetching provinces:", err);
+                setProvinceError(
+                    err.message ||
+                    "Failed to load provinces. Please try again later."
+                );
+            } finally {
+                setIsLoadingProvinces(false);
+            }
+        };
 
-	// Fetch divisions
-	useEffect(() => {
-		const fetchDivisions = async () => {
-			setIsLoadingDivisions(true);
-			setDivisionError(null);
-			try {
-				const divisionData = await fetchWithErrorHandling(
-					"/misapi/api/ordinary/region"
-				);
-				const sortedDivisions = (divisionData.data || []).sort(
-					(a: Division, b: Division) =>
-						a.RegionCode.localeCompare(b.RegionCode)
-				);
-				setDivisions(sortedDivisions);
-			} catch (err: any) {
-				console.error("Error fetching divisions:", err);
-				setDivisionError(
-					err.message ||
-						"Failed to load divisions. Please try again later."
-				);
-			} finally {
-				setIsLoadingDivisions(false);
-			}
-		};
+        fetchProvinces();
+    }, [user.Level]);
 
-		fetchDivisions();
-	}, []);
+    // Fetch divisions
+    useEffect(() => {
+        const fetchDivisions = async () => {
+            setIsLoadingDivisions(true);
+            setDivisionError(null);
+            try {
+                const divisionData = await fetchWithErrorHandling(
+                    "/misapi/api/ordinary/region"
+                );
+                const sortedDivisions = (divisionData.data || []).sort(
+                    (a: Division, b: Division) =>
+                        a.RegionCode.localeCompare(b.RegionCode)
+                );
+                setDivisions(sortedDivisions);
+            } catch (err: any) {
+                console.error("Error fetching divisions:", err);
+                setDivisionError(
+                    err.message ||
+                    "Failed to load divisions. Please try again later."
+                );
+            } finally {
+                setIsLoadingDivisions(false);
+            }
+        };
 
-	// Fetch cycles based on cycle type
-	useEffect(() => {
-		if (!selectedCycleType) {
-			setCycleOptions([]);
-			setCycleValue("");
-			setSelectedCycleDisplay("");
-			return;
-		}
+        fetchDivisions();
+    }, []);
 
-		const fetchCycles = async () => {
-			setIsLoadingCycles(true);
-			setCycleError(null);
-			setCycleOptions([]);
-			setCycleValue("");
-			setSelectedCycleDisplay("");
+    useEffect(() => {
+        const key = selectedCategory === "Division" ? "Region" : selectedCategory;
+        const lock = locked[key as keyof typeof locked];
+        if (lock) {
+            setCategoryValue(lock.code);
+            setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+        }
+    }, [selectedCategory, locked]);
 
-			try {
-				const cycleData = await fetchWithErrorHandling(
-					"/misapi/api/ordinary/netmtcons/billcycle/max"
-				);
-				if (cycleData.data && cycleData.data.BillCycles?.length > 0) {
-					const options = generateCycleOptions(
-						cycleData.data.BillCycles,
-						cycleData.data.MaxBillCycle,
-						selectedCycleType
-					);
-					setCycleOptions(options);
-				} else {
-					setCycleOptions([]);
-				}
-			} catch (err: any) {
-				console.error("Error fetching cycles:", err);
-				setCycleError(
-					err.message || "Failed to load cycles. Please try again later."
-				);
-			} finally {
-				setIsLoadingCycles(false);
-			}
-		};
+    // Fetch cycles based on cycle type
+    useEffect(() => {
+        if (!selectedCycleType) {
+            setCycleOptions([]);
+            setCycleValue("");
+            setSelectedCycleDisplay("");
+            return;
+        }
 
-		fetchCycles();
-	}, [selectedCycleType]);
+        const fetchCycles = async () => {
+            setIsLoadingCycles(true);
+            setCycleError(null);
+            setCycleOptions([]);
+            setCycleValue("");
+            setSelectedCycleDisplay("");
 
-	const handleCycleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const value = e.target.value;
-		setSelectedCycleType(value);
-		setCycleValue("");
-		setSelectedCycleDisplay("");
-	};
+            try {
+                const cycleData = await fetchWithErrorHandling(
+                    "/misapi/api/ordinary/netmtcons/billcycle/max"
+                );
+                if (cycleData.data && cycleData.data.BillCycles?.length > 0) {
+                    const options = generateCycleOptions(
+                        cycleData.data.BillCycles,
+                        cycleData.data.MaxBillCycle,
+                        selectedCycleType
+                    );
+                    setCycleOptions(options);
+                } else {
+                    setCycleOptions([]);
+                }
+            } catch (err: any) {
+                console.error("Error fetching cycles:", err);
+                setCycleError(
+                    err.message || "Failed to load cycles. Please try again later."
+                );
+            } finally {
+                setIsLoadingCycles(false);
+            }
+        };
 
-	const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const value = e.target.value;
-		setSelectedCategory(value);
-		setCategoryValue("");
-		setSelectedCategoryName("");
-	};
+        fetchCycles();
+    }, [selectedCycleType]);
 
-	const formatCurrency = (value: number): string => {
-		return value.toLocaleString("en-US", {
-			minimumFractionDigits: 2,
-			maximumFractionDigits: 2,
-		});
-	};
+    const handleCycleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        setSelectedCycleType(value);
+        setCycleValue("");
+        setSelectedCycleDisplay("");
+    };
 
-	const formatNumber = (value: string | number): string => {
-		return typeof value === "number" ? value.toLocaleString("en-US") : value;
-	};
+    const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        setSelectedCategory(value);
+        setCategoryValue("");
+        setSelectedCategoryName("");
+    };
 
-	const downloadAsCSV = () => {
-		if (reportType === "Summary Report") {
-			downloadSummaryCSV();
-		} else if (detailedData.length) {
-			downloadDetailedCSV();
-		}
-	};
+    const formatCurrency = (value: number): string => {
+        return value.toLocaleString("en-US", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    };
 
-	const downloadDetailedCSV = () => {
-		if (!detailedData.length) return;
+    const formatNumber = (value: string | number): string => {
+        return typeof value === "number" ? value.toLocaleString("en-US") : value;
+    };
 
-		const reportTitle =
-			"Solar Payment Information For Current Month - Retail";
-		const selectionInfo =
-			selectedCategory === "Entire CEB"
-				? "Entire CEB"
-				: selectedCategory === "Area"
-				? `${selectedCategory}: ${selectedCategoryName}`
-				: `${selectedCategory}: ${categoryValue}`;
+    const downloadAsCSV = () => {
+        if (reportType === "Summary Report") {
+            downloadSummaryCSV();
+        } else if (detailedData.length) {
+            downloadDetailedCSV();
+        }
+    };
+
+    const downloadDetailedCSV = () => {
+        if (!detailedData.length) return;
+
+        const reportTitle =
+            "Solar Payment Information For Current Month - Retail";
+        const selectionInfo =
+            selectedCategory === "Entire CEB"
+                ? "Entire CEB"
+                : selectedCategory === "Area"
+                    ? `${selectedCategory}: ${selectedCategoryName}`
+                    : `${selectedCategory}: ${categoryValue}`;
 
         const cycleInfo = `${selectedCycleType}: ${selectedCycleDisplay}`;
         const reportTypeInfo = `Report Type: ${reportType}`;
@@ -607,214 +629,214 @@ const SolarPaymentRetail: React.FC = () => {
             ...dataRows,
         ].join("\n");
 
-		try {
-			const blob = new Blob([csvContent], {type: "text/csv;charset=utf-8;"});
-			const url = URL.createObjectURL(blob);
-			const link = document.createElement("a");
+        try {
+            const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
 
-			const fileDescriptor =
-				selectedCategory === "Entire CEB"
-					? "EntireCEB"
-					: selectedCategory === "Area"
-					? `${selectedCategory}_${selectedCategoryName}`
-					: `${selectedCategory}_${categoryValue}`;
+            const fileDescriptor =
+                selectedCategory === "Entire CEB"
+                    ? "EntireCEB"
+                    : selectedCategory === "Area"
+                        ? `${selectedCategory}_${selectedCategoryName}`
+                        : `${selectedCategory}_${categoryValue}`;
 
-			link.setAttribute("href", url);
-			link.setAttribute(
-				"download",
-				`SolarPaymentRetail_${fileDescriptor}_${selectedCycleType.replace(
-					" ",
-					""
-				)}_${cycleValue}.csv`
-			);
-			link.style.visibility = "hidden";
-			document.body.appendChild(link);
-			link.click();
-			document.body.removeChild(link);
-			setTimeout(() => URL.revokeObjectURL(url), 100);
-		} catch (error) {
-			console.error("Error generating CSV:", error);
-			alert("Failed to export CSV");
-		}
-	};
+            link.setAttribute("href", url);
+            link.setAttribute(
+                "download",
+                `SolarPaymentRetail_${fileDescriptor}_${selectedCycleType.replace(
+                    " ",
+                    ""
+                )}_${cycleValue}.csv`
+            );
+            link.style.visibility = "hidden";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            setTimeout(() => URL.revokeObjectURL(url), 100);
+        } catch (error) {
+            console.error("Error generating CSV:", error);
+            alert("Failed to export CSV");
+        }
+    };
 
-	const downloadSummaryCSV = () => {
-		const reportTitle =
-			"Solar Payment Information For Current Month - Retail Summary";
-		const headers = [
-			"Net Type",
-			"No of Accounts",
-			"Energy Exported (kWh)",
-			"Energy Imported (kWh)",
-			"Unit Sale (KWH)",
-			"Unit Sale (Rs)",
-			"KWH payable balances to Customer (Rs)",
-		];
+    const downloadSummaryCSV = () => {
+        const reportTitle =
+            "Solar Payment Information For Current Month - Retail Summary";
+        const headers = [
+            "Net Type",
+            "No of Accounts",
+            "Energy Exported (kWh)",
+            "Energy Imported (kWh)",
+            "Unit Sale (KWH)",
+            "Unit Sale (Rs)",
+            "KWH payable balances to Customer (Rs)",
+        ];
 
-		// Calculate totals for ordinary
-		const ordinaryTotals = ordinarySummaryData.reduce(
-			(acc, item) => {
-				acc.accounts += item.NoOfAccounts;
-				acc.exported += item.EnergyExported;
-				acc.imported += item.EnergyImported;
-				acc.unitSaleKwh += item.UnitSaleKwh;
-				acc.unitSaleRs += item.UnitSaleRs;
-				acc.payableBalance += item.KwhPayableBalance;
-				return acc;
-			},
-			{
-				accounts: 0,
-				exported: 0,
-				imported: 0,
-				unitSaleKwh: 0,
-				unitSaleRs: 0,
-				payableBalance: 0,
-			}
-		);
+        // Calculate totals for ordinary
+        const ordinaryTotals = ordinarySummaryData.reduce(
+            (acc, item) => {
+                acc.accounts += item.NoOfAccounts;
+                acc.exported += item.EnergyExported;
+                acc.imported += item.EnergyImported;
+                acc.unitSaleKwh += item.UnitSaleKwh;
+                acc.unitSaleRs += item.UnitSaleRs;
+                acc.payableBalance += item.KwhPayableBalance;
+                return acc;
+            },
+            {
+                accounts: 0,
+                exported: 0,
+                imported: 0,
+                unitSaleKwh: 0,
+                unitSaleRs: 0,
+                payableBalance: 0,
+            }
+        );
 
-		// Calculate totals for bulk
-		const bulkTotals = bulkSummaryData.reduce(
-			(acc, item) => {
-				acc.accounts += item.NoOfAccounts;
-				acc.exported += item.EnergyExported;
-				acc.imported += item.EnergyImported;
-				acc.unitSaleKwh += item.UnitSaleKwh;
-				acc.unitSaleRs += item.UnitSaleRs;
-				acc.payableBalance += item.KwhPayableBalance;
-				return acc;
-			},
-			{
-				accounts: 0,
-				exported: 0,
-				imported: 0,
-				unitSaleKwh: 0,
-				unitSaleRs: 0,
-				payableBalance: 0,
-			}
-		);
+        // Calculate totals for bulk
+        const bulkTotals = bulkSummaryData.reduce(
+            (acc, item) => {
+                acc.accounts += item.NoOfAccounts;
+                acc.exported += item.EnergyExported;
+                acc.imported += item.EnergyImported;
+                acc.unitSaleKwh += item.UnitSaleKwh;
+                acc.unitSaleRs += item.UnitSaleRs;
+                acc.payableBalance += item.KwhPayableBalance;
+                return acc;
+            },
+            {
+                accounts: 0,
+                exported: 0,
+                imported: 0,
+                unitSaleKwh: 0,
+                unitSaleRs: 0,
+                payableBalance: 0,
+            }
+        );
 
-		const ordinaryRows = ordinarySummaryData.map((item) => [
-			item.NetType,
-			formatNumber(item.NoOfAccounts),
-			formatNumber(item.EnergyExported),
-			formatNumber(item.EnergyImported),
-			formatNumber(item.UnitSaleKwh),
-			formatNumber(item.UnitSaleRs),
-			formatNumber(item.KwhPayableBalance),
-		]);
+        const ordinaryRows = ordinarySummaryData.map((item) => [
+            item.NetType,
+            formatNumber(item.NoOfAccounts),
+            formatNumber(item.EnergyExported),
+            formatNumber(item.EnergyImported),
+            formatNumber(item.UnitSaleKwh),
+            formatNumber(item.UnitSaleRs),
+            formatNumber(item.KwhPayableBalance),
+        ]);
 
-		const ordinaryTotalRow = [
-			"Total",
-			ordinaryTotals.accounts.toLocaleString(),
-			ordinaryTotals.exported.toLocaleString(),
-			ordinaryTotals.imported.toLocaleString(),
-			ordinaryTotals.unitSaleKwh.toLocaleString(),
-			formatCurrency(ordinaryTotals.unitSaleRs),
-			formatCurrency(ordinaryTotals.payableBalance),
-		];
+        const ordinaryTotalRow = [
+            "Total",
+            ordinaryTotals.accounts.toLocaleString(),
+            ordinaryTotals.exported.toLocaleString(),
+            ordinaryTotals.imported.toLocaleString(),
+            ordinaryTotals.unitSaleKwh.toLocaleString(),
+            formatCurrency(ordinaryTotals.unitSaleRs),
+            formatCurrency(ordinaryTotals.payableBalance),
+        ];
 
-		const bulkRows = bulkSummaryData.map((item) => [
-			item.NetType,
-			formatNumber(item.NoOfAccounts),
-			formatNumber(item.EnergyExported),
-			formatNumber(item.EnergyImported),
-			formatNumber(item.UnitSaleKwh),
-			formatNumber(item.UnitSaleRs),
-			formatNumber(item.KwhPayableBalance),
-		]);
+        const bulkRows = bulkSummaryData.map((item) => [
+            item.NetType,
+            formatNumber(item.NoOfAccounts),
+            formatNumber(item.EnergyExported),
+            formatNumber(item.EnergyImported),
+            formatNumber(item.UnitSaleKwh),
+            formatNumber(item.UnitSaleRs),
+            formatNumber(item.KwhPayableBalance),
+        ]);
 
-		const bulkTotalRow =
-			bulkSummaryData.length > 0
-				? [
-						"Total",
-						bulkTotals.accounts.toLocaleString(),
-						bulkTotals.exported.toLocaleString(),
-						bulkTotals.imported.toLocaleString(),
-						bulkTotals.unitSaleKwh.toLocaleString(),
-						formatCurrency(bulkTotals.unitSaleRs),
-						formatCurrency(bulkTotals.payableBalance),
-				  ]
-				: [];
+        const bulkTotalRow =
+            bulkSummaryData.length > 0
+                ? [
+                    "Total",
+                    bulkTotals.accounts.toLocaleString(),
+                    bulkTotals.exported.toLocaleString(),
+                    bulkTotals.imported.toLocaleString(),
+                    bulkTotals.unitSaleKwh.toLocaleString(),
+                    formatCurrency(bulkTotals.unitSaleRs),
+                    formatCurrency(bulkTotals.payableBalance),
+                ]
+                : [];
 
-		const csvRows = [
-			reportTitle,
-			`${selectedCycleType}: ${selectedCycleDisplay}`,
-			`Generated: ${new Date().toLocaleDateString()}`,
-			"",
-			"Ordinary Customer Details",
-			headers.map((h) => `"${h}"`).join(","),
-			...ordinaryRows.map((row) =>
-				row.map((cell: any) => `"${cell}"`).join(",")
-			),
-			ordinaryTotalRow.map((cell: any) => `"${cell}"`).join(","),
-		];
+        const csvRows = [
+            reportTitle,
+            `${selectedCycleType}: ${selectedCycleDisplay}`,
+            `Generated: ${new Date().toLocaleDateString()}`,
+            "",
+            "Ordinary Customer Details",
+            headers.map((h) => `"${h}"`).join(","),
+            ...ordinaryRows.map((row) =>
+                row.map((cell: any) => `"${cell}"`).join(",")
+            ),
+            ordinaryTotalRow.map((cell: any) => `"${cell}"`).join(","),
+        ];
 
-		if (bulkSummaryData.length > 0) {
-			csvRows.push(
-				"",
-				"Bulk Customer Details",
-				headers.map((h) => `"${h}"`).join(","),
-				...bulkRows.map((row) =>
-					row.map((cell: any) => `"${cell}"`).join(",")
-				),
-				bulkTotalRow.map((cell: any) => `"${cell}"`).join(",")
-			);
-		}
+        if (bulkSummaryData.length > 0) {
+            csvRows.push(
+                "",
+                "Bulk Customer Details",
+                headers.map((h) => `"${h}"`).join(","),
+                ...bulkRows.map((row) =>
+                    row.map((cell: any) => `"${cell}"`).join(",")
+                ),
+                bulkTotalRow.map((cell: any) => `"${cell}"`).join(",")
+            );
+        }
 
-		const csvContent = csvRows.join("\n");
+        const csvContent = csvRows.join("\n");
 
-		try {
-			const blob = new Blob([csvContent], {type: "text/csv;charset=utf-8;"});
-			const url = URL.createObjectURL(blob);
-			const link = document.createElement("a");
+        try {
+            const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
 
-			link.setAttribute("href", url);
-			link.setAttribute(
-				"download",
-				`SolarPaymentRetail_Summary_${selectedCycleType.replace(
-					" ",
-					""
-				)}_${cycleValue}.csv`
-			);
-			link.style.visibility = "hidden";
-			document.body.appendChild(link);
-			link.click();
-			document.body.removeChild(link);
-			setTimeout(() => URL.revokeObjectURL(url), 100);
-		} catch (error) {
-			console.error("Error generating CSV:", error);
-			alert("Failed to export CSV");
-		}
-	};
+            link.setAttribute("href", url);
+            link.setAttribute(
+                "download",
+                `SolarPaymentRetail_Summary_${selectedCycleType.replace(
+                    " ",
+                    ""
+                )}_${cycleValue}.csv`
+            );
+            link.style.visibility = "hidden";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            setTimeout(() => URL.revokeObjectURL(url), 100);
+        } catch (error) {
+            console.error("Error generating CSV:", error);
+            alert("Failed to export CSV");
+        }
+    };
 
-	const printPDF = () => {
-		if (!printRef.current) return;
+    const printPDF = () => {
+        if (!printRef.current) return;
 
-		const printWindow = window.open("", "_blank");
-		if (!printWindow) return;
+        const printWindow = window.open("", "_blank");
+        if (!printWindow) return;
 
-		let reportTitle = "";
-		let selectionInfo = "";
+        let reportTitle = "";
+        let selectionInfo = "";
 
-		if (reportType === "Summary Report") {
-			reportTitle =
-				"SOLAR PAYMENT INFORMATION FOR CURRENT MONTH - RETAIL SUMMARY";
-			selectionInfo = `${selectedCycleType}: <span class="bold">${selectedCycleDisplay}</span>`;
-		} else {
-			reportTitle = "SOLAR PAYMENT INFORMATION FOR CURRENT MONTH - RETAIL";
-			const categoryInfo = (() => {
-				if (selectedCategory === "Entire CEB") {
-					return "Entire CEB";
-				} else if (selectedCategory === "Area") {
-					return `${selectedCategory}: <span class="bold">${selectedCategoryName}</span>`;
-				} else {
-					return `${selectedCategory}: <span class="bold">${categoryValue}</span>`;
-				}
-			})();
-			selectionInfo = `${categoryInfo}<br>${selectedCycleType}: <span class="bold">${selectedCycleDisplay}</span><br>Report Type: <span class="bold">${reportType}</span><br>Net Type: <span class="bold">${netType}</span>`;
-		}
+        if (reportType === "Summary Report") {
+            reportTitle =
+                "SOLAR PAYMENT INFORMATION FOR CURRENT MONTH - RETAIL SUMMARY";
+            selectionInfo = `${selectedCycleType}: <span class="bold">${selectedCycleDisplay}</span>`;
+        } else {
+            reportTitle = "SOLAR PAYMENT INFORMATION FOR CURRENT MONTH - RETAIL";
+            const categoryInfo = (() => {
+                if (selectedCategory === "Entire CEB") {
+                    return "Entire CEB";
+                } else if (selectedCategory === "Area") {
+                    return `${selectedCategory}: <span class="bold">${selectedCategoryName}</span>`;
+                } else {
+                    return `${selectedCategory}: <span class="bold">${categoryValue}</span>`;
+                }
+            })();
+            selectionInfo = `${categoryInfo}<br>${selectedCycleType}: <span class="bold">${selectedCycleDisplay}</span><br>Report Type: <span class="bold">${reportType}</span><br>Net Type: <span class="bold">${netType}</span>`;
+        }
 
-		printWindow.document.write(`
+        printWindow.document.write(`
       <html>
         <head>
           <title>Solar Payment Retail Report</title>
@@ -1420,7 +1442,7 @@ const SolarPaymentRetail: React.FC = () => {
                             <td className="border border-gray-300 px-2 py-1" colSpan={2}>
                                 Province Total
                             </td>
-                            
+
                             <td className="border border-gray-300 px-2 py-1 text-right">
                                 {totals.count}
                             </td>
@@ -1455,7 +1477,7 @@ const SolarPaymentRetail: React.FC = () => {
                         <td className="border border-gray-300 px-2 py-1" colSpan={3}>
                             Division Total
                         </td>
-                        
+
                         <td className="border border-gray-300 px-2 py-1 text-right">
                             {totals.count}
                         </td>
@@ -1939,10 +1961,11 @@ const SolarPaymentRetail: React.FC = () => {
                                     required={reportType === "Detailed Report"}
                                     disabled={isCategoryDisabled()}
                                 >
-                                    <option value="Area">Area</option>
-                                    <option value="Province">Province</option>
-                                    <option value="Division">Division</option>
-                                    <option value="Entire CEB">Entire CEB</option>
+                                    {allowedCategories.map((cat) => (
+                                        <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                                            {cat === "Region" ? "Division" : cat}
+                                        </option>
+                                    ))}
                                 </select>
                             </div>
 
@@ -1981,6 +2004,16 @@ const SolarPaymentRetail: React.FC = () => {
                                         </div>
                                     ) : areaError ? (
                                         <div className="text-red-500 text-xs py-2">{areaError}</div>
+                                    ) : locked["Area"] ? (
+                                        <select
+                                            disabled
+                                            value={locked["Area"].code}
+                                            className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        >
+                                            <option value={locked["Area"].code}>
+                                                {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                                            </option>
+                                        </select>
                                     ) : (
                                         <select
                                             value={categoryValue}
@@ -2049,6 +2082,16 @@ const SolarPaymentRetail: React.FC = () => {
                                         <div className="text-red-500 text-xs py-2">
                                             {provinceError}
                                         </div>
+                                    ) : locked["Province"] ? (
+                                        <select
+                                            disabled
+                                            value={locked["Province"].code}
+                                            className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        >
+                                            <option value={locked["Province"].code}>
+                                                {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                                            </option>
+                                        </select>
                                     ) : (
                                         <select
                                             value={categoryValue}
@@ -2120,6 +2163,14 @@ const SolarPaymentRetail: React.FC = () => {
                                         <div className="text-red-500 text-xs py-2">
                                             {divisionError}
                                         </div>
+                                    ) : locked["Region"] ? (
+                                        <select
+                                            disabled
+                                            value={locked["Region"].code}
+                                            className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                                        >
+                                            <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                                        </select>
                                     ) : (
                                         <select
                                             value={categoryValue}
@@ -2245,7 +2296,7 @@ const SolarPaymentRetail: React.FC = () => {
                                     <>
                                         {selectedCategory === "Entire CEB"
                                             ? "Entire CEB"
-                                            : `${selectedCategory}: ${selectedCategoryName} `} 
+                                            : `${selectedCategory}: ${selectedCategoryName} `}
                                         | {selectedCycleType}: {selectedCycleDisplay} | Type:{" "}
                                         {reportType} | Net Type: {netType}
                                     </>
@@ -2277,8 +2328,8 @@ const SolarPaymentRetail: React.FC = () => {
                     {/* Report Table */}
                     <div
                         className={`${reportType === "Summary Report"
-                                ? ""
-                                : "overflow-x-auto max-h-[calc(100vh-250px)]"
+                            ? ""
+                            : "overflow-x-auto max-h-[calc(100vh-250px)]"
                             } border border-gray-300 rounded-lg`}
                     >
                         <div ref={printRef} className="min-w-full py-4">

--- a/src/mainTopics/SolarInformation/SolarProgressClarificationBulk.tsx
+++ b/src/mainTopics/SolarInformation/SolarProgressClarificationBulk.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaArrowLeft, FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   AreaCode: string;
@@ -76,6 +78,9 @@ const SolarProgressClarificationBulk: React.FC = () => {
   const [detailedData, setDetailedData] = useState<DetailedSolarProgress[]>([]);
   const [summaryData, setSummaryData] = useState<SummarySolarProgress[]>([]);
   const [reportError, setReportError] = useState<string | null>(null);
+
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
   const printRef = useRef<HTMLDivElement>(null);
 
   // Helper function for error handling
@@ -127,48 +132,55 @@ const SolarProgressClarificationBulk: React.FC = () => {
 
   // Fetch areas
   useEffect(() => {
-    const fetchAreas = async () => {
-      setIsLoadingAreas(true);
-      setAreaError(null);
-      try {
-        // Using the API endpoint
-        const areaData = await fetchWithErrorHandling("/misapi/api/bulk/areas");
-        setAreas(areaData.data || []);
-      } catch (err: any) {
-        console.error("Error fetching areas:", err);
-        setAreaError(
-          err.message || "Failed to load areas. Please try again later."
-        );
-      } finally {
-        setIsLoadingAreas(false);
+  const fetchAreas = async () => {
+    setIsLoadingAreas(true);
+    setAreaError(null);
+    try {
+      let url = "/misapi/api/bulk/areas";
+      if (locked["Region"]?.code) {
+        url += `?regionCode=${locked["Region"].code}`;
+      } else if (locked["Province"]?.code) {
+        url += `?provCode=${locked["Province"].code}`;
       }
-    };
+      const areaData = await fetchWithErrorHandling(url);
+      setAreas(areaData.data || []);
+    } catch (err: any) {
+      console.error("Error fetching areas:", err);
+      setAreaError(
+        err.message || "Failed to load areas. Please try again later."
+      );
+    } finally {
+      setIsLoadingAreas(false);
+    }
+  };
 
-    fetchAreas();
-  }, []);
+  fetchAreas();
+}, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // Fetch provinces/
   useEffect(() => {
-    const fetchProvinces = async () => {
-      setIsLoadingProvinces(true);
-      setProvinceError(null);
-      try {
-        const provinceData = await fetchWithErrorHandling(
-          "/misapi/api/bulk/province"
-        );
-        setProvinces(provinceData.data || []);
-      } catch (err: any) {
-        console.error("Error fetching provinces:", err);
-        setProvinceError(
-          err.message || "Failed to load provinces. Please try again later."
-        );
-      } finally {
-        setIsLoadingProvinces(false);
+  const fetchProvinces = async () => {
+    setIsLoadingProvinces(true);
+    setProvinceError(null);
+    try {
+      let url = "/misapi/api/bulk/province";
+      if (locked["Region"]?.code) {
+        url += `?regionCode=${locked["Region"].code}`;
       }
-    };
+      const provinceData = await fetchWithErrorHandling(url);
+      setProvinces(provinceData.data || []);
+    } catch (err: any) {
+      console.error("Error fetching provinces:", err);
+      setProvinceError(
+        err.message || "Failed to load provinces. Please try again later."
+      );
+    } finally {
+      setIsLoadingProvinces(false);
+    }
+  };
 
-    fetchProvinces();
-  }, []);
+  fetchProvinces();
+}, [user.Level, user.RegionCode]);
 
   // Fetch divisions
   useEffect(() => {
@@ -192,6 +204,16 @@ const SolarProgressClarificationBulk: React.FC = () => {
 
     fetchDivisions();
   }, []);
+
+
+  useEffect(() => {
+  const key = selectedOption === "Division" ? "Region" : selectedOption;
+  const lock = locked[key as keyof typeof locked];
+  if (lock) {
+    setInputValue(lock.code);
+    setSelectedAreaName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+  }
+}, [selectedOption, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
   // Fetch bill cycles
   useEffect(() => {
@@ -977,10 +999,11 @@ const SolarProgressClarificationBulk: React.FC = () => {
                   className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
                   required
                 >
-                  <option value="Area">Area</option>
-                  <option value="Province">Province</option>
-                  <option value="Division">Division</option>
-                  <option value="Entire CEB">Entire CEB</option>
+                  {allowedCategories.map((cat) => (
+  <option key={cat} value={cat === "Region" ? "Division" : cat}>
+    {cat === "Region" ? "Division" : cat}
+  </option>
+))}
                 </select>
               </div>
 
@@ -1016,32 +1039,41 @@ const SolarProgressClarificationBulk: React.FC = () => {
                     </div>
                   ) : areaError ? (
                     <div className="text-red-500 text-xs py-2">{areaError}</div>
-                  ) : (
-                    <select
-                      value={inputValue}
-                      onChange={(e) => {
-                        const selectedAreaCode = e.target.value;
-                        setInputValue(selectedAreaCode);
-                        // Find and store the area name
-                        const selectedArea = areas.find(
-                          (area) => area.AreaCode === selectedAreaCode
-                        );
-                        setSelectedAreaName(
-                          selectedArea ? selectedArea.AreaName : ""
-                        );
-                      }}
-                      className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-                      required
-                      disabled={isLoadingAreas || areaError !== null}
-                    >
-                      <option value="">Select Area</option>
-                      {areas.map((area) => (
-                        <option key={area.AreaCode} value={area.AreaCode}>
-                          {formatAreaOption(area)}
-                        </option>
-                      ))}
-                    </select>
-                  )}
+                  ) : locked["Area"] ? (
+  <select
+    disabled
+    value={locked["Area"].code}
+    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+  >
+    <option value={locked["Area"].code}>
+      {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+    </option>
+  </select>
+) : (
+  <select
+    value={inputValue}
+    onChange={(e) => {
+      const selectedAreaCode = e.target.value;
+      setInputValue(selectedAreaCode);
+      const selectedArea = areas.find(
+        (area) => area.AreaCode === selectedAreaCode
+      );
+      setSelectedAreaName(
+        selectedArea ? selectedArea.AreaName : ""
+      );
+    }}
+    className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+    required
+    disabled={isLoadingAreas || areaError !== null}
+  >
+    <option value="">Select Area</option>
+    {areas.map((area) => (
+      <option key={area.AreaCode} value={area.AreaCode}>
+        {formatAreaOption(area)}
+      </option>
+    ))}
+  </select>
+)}
                 </div>
               )}
 
@@ -1078,25 +1110,32 @@ const SolarProgressClarificationBulk: React.FC = () => {
                     <div className="text-red-500 text-xs py-2">
                       {provinceError}
                     </div>
-                  ) : (
-                    <select
-                      value={inputValue}
-                      onChange={(e) => setInputValue(e.target.value)}
-                      className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-                      required
-                      disabled={isLoadingProvinces || provinceError !== null}
-                    >
-                      <option value="">Select Province</option>
-                      {provinces.map((province) => (
-                        <option
-                          key={province.ProvinceCode}
-                          value={province.ProvinceCode}
-                        >
-                          {formatProvinceOption(province)}
-                        </option>
-                      ))}
-                    </select>
-                  )}
+                  ) : locked["Province"] ? (
+  <select
+    disabled
+    value={locked["Province"].code}
+    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+  >
+    <option value={locked["Province"].code}>
+      {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+    </option>
+  </select>
+) : (
+  <select
+    value={inputValue}
+    onChange={(e) => setInputValue(e.target.value)}
+    className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+    required
+    disabled={isLoadingProvinces || provinceError !== null}
+  >
+    <option value="">Select Province</option>
+    {provinces.map((province) => (
+      <option key={province.ProvinceCode} value={province.ProvinceCode}>
+        {formatProvinceOption(province)}
+      </option>
+    ))}
+  </select>
+)}
                 </div>
               )}
 
@@ -1133,25 +1172,30 @@ const SolarProgressClarificationBulk: React.FC = () => {
                     <div className="text-red-500 text-xs py-2">
                       {divisionError}
                     </div>
-                  ) : (
-                    <select
-                      value={inputValue}
-                      onChange={(e) => setInputValue(e.target.value)}
-                      className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-                      required
-                      disabled={isLoadingDivisions || divisionError !== null}
-                    >
-                      <option value="">Select Division</option>
-                      {divisions.map((division) => (
-                        <option
-                          key={division.RegionCode}
-                          value={division.RegionCode}
-                        >
-                          {formatDivisionOption(division)}
-                        </option>
-                      ))}
-                    </select>
-                  )}
+                  ) : locked["Region"] ? (
+  <select
+    disabled
+    value={locked["Region"].code}
+    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+  >
+    <option value={locked["Region"].code}>{locked["Region"].code}</option>
+  </select>
+) : (
+  <select
+    value={inputValue}
+    onChange={(e) => setInputValue(e.target.value)}
+    className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+    required
+    disabled={isLoadingDivisions || divisionError !== null}
+  >
+    <option value="">Select Division</option>
+    {divisions.map((division) => (
+      <option key={division.RegionCode} value={division.RegionCode}>
+        {formatDivisionOption(division)}
+      </option>
+    ))}
+  </select>
+)}
                 </div>
               )}
 

--- a/src/mainTopics/SolarInformation/SolarProgressClarificationOrdinary.tsx
+++ b/src/mainTopics/SolarInformation/SolarProgressClarificationOrdinary.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaArrowLeft, FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   AreaCode: string;
@@ -76,6 +78,8 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
   const [detailedData, setDetailedData] = useState<DetailedSolarProgress[]>([]);
   const [summaryData, setSummaryData] = useState<SummarySolarProgress[]>([]);
   const [reportError, setReportError] = useState<string | null>(null);
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
   const printRef = useRef<HTMLDivElement>(null);
 
   // Helper function for error handling
@@ -131,8 +135,13 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
       setIsLoadingAreas(true);
       setAreaError(null);
       try {
-        // Using the same API endpoint pattern as AgeAnalysis
-        const areaData = await fetchWithErrorHandling("/misapi/api/ordinary/areas");
+        let url = "/misapi/api/ordinary/areas";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          url += `?provCode=${locked["Province"].code}`;
+        }
+        const areaData = await fetchWithErrorHandling(url);
         setAreas(areaData.data || []);
       } catch (err: any) {
         console.error("Error fetching areas:", err);
@@ -145,7 +154,7 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
     };
 
     fetchAreas();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // Fetch provinces/
   useEffect(() => {
@@ -153,9 +162,11 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
       setIsLoadingProvinces(true);
       setProvinceError(null);
       try {
-        const provinceData = await fetchWithErrorHandling(
-          "/misapi/api/ordinary/province"
-        );
+        let url = "/misapi/api/ordinary/province";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        }
+        const provinceData = await fetchWithErrorHandling(url);
         setProvinces(provinceData.data || []);
       } catch (err: any) {
         console.error("Error fetching provinces:", err);
@@ -168,7 +179,7 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
     };
 
     fetchProvinces();
-  }, []);
+  }, [user.Level, user.RegionCode]);
 
   // Fetch divisions
   useEffect(() => {
@@ -192,6 +203,15 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
 
     fetchDivisions();
   }, []);
+
+  useEffect(() => {
+    const key = selectedOption === "Division" ? "Region" : selectedOption;
+    const lock = locked[key as keyof typeof locked];
+    if (lock) {
+      setInputValue(lock.code);
+      setSelectedAreaName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+    }
+  }, [selectedOption, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
   // Fetch bill cycles
   useEffect(() => {
@@ -245,129 +265,129 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
   };
 
   const downloadAsCSV = () => {
-  if (reportType === "detailed" && !detailedData.length) return;
-  if (reportType === "summary" && !summaryData.length) return;
+    if (reportType === "detailed" && !detailedData.length) return;
+    if (reportType === "summary" && !summaryData.length) return;
 
-  const reportTitle =
-    reportType === "detailed"
-      ? "Solar Progress Detailed Report"
-      : "Solar Progress Summary Report";
+    const reportTitle =
+      reportType === "detailed"
+        ? "Solar Progress Detailed Report"
+        : "Solar Progress Summary Report";
 
-  const selectionInfo =
-    selectedOption === "Entire CEB"
-      ? "Entire CEB"
-      : selectedOption === "Area"
-      ? `${selectedOption}: ${selectedAreaName}`
-      : `${selectedOption}: ${inputValue}`;
-
-  let csvContent = "";
-  let headers: string[] = [];
-  let rows: any[] = [];
-
-  if (reportType === "detailed") {
-    headers = [
-      "Region",
-      "Province",
-      "Area",
-      "Account Number",
-      "Net Type",
-      "Description",
-      "Capacity",
-      "From Area",
-      "To Area",
-      "From Net Type",
-      "To Net Type",
-    ];
-
-    // Sort data to match table order
-    const sortedData = [...detailedData].sort((a, b) => {
-      if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
-      if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
-      return a.Area.localeCompare(b.Area);
-    });
-
-    // Build rows - include Region/Province/Area on EVERY row for CSV
-    rows = sortedData.map((item) => [
-      item.Region,
-      item.Province,
-      item.Area,
-      item.AccountNumber,
-      item.NetType,
-      item.Description,
-      item.Capacity,
-      item.FromArea || "",
-      item.ToArea || "",
-      item.FromNetType || "",
-      item.ToNetType || "",
-    ]);
-  } else {
-    headers = [
-      "Region",
-      "Province",
-      "Area",
-      "Description",
-      "Count",
-      "Capacity",
-    ];
-
-    // Sort data to match table order
-    const sortedData = [...summaryData].sort((a, b) => {
-      if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
-      if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
-      return a.Area.localeCompare(b.Area);
-    });
-
-    // Build rows - include Region/Province/Area on EVERY row for CSV
-    rows = sortedData.map((item) => [
-      item.Region,
-      item.Province,
-      item.Area,
-      item.Description,
-      item.Count,
-      item.Capacity,
-    ]);
-  }
-
-  // Build CSV content with proper structure
-  csvContent = [
-    reportTitle,
-    selectionInfo,
-    `Bill Cycle: ${selectedBillCycleDisplay}`,
-    `Generated: ${new Date().toLocaleDateString()}`,
-    "",
-    headers.map((h) => `"${h}"`).join(","),
-    ...rows.map((row) => row.map((cell: any) => `"${cell}"`).join(",")),
-  ].join("\n");
-
-  try {
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-
-    const fileDescriptor =
+    const selectionInfo =
       selectedOption === "Entire CEB"
-        ? "EntireCEB"
+        ? "Entire CEB"
         : selectedOption === "Area"
-        ? `${selectedOption}_${selectedAreaName}`
-        : `${selectedOption}_${inputValue}`;
+          ? `${selectedOption}: ${selectedAreaName}`
+          : `${selectedOption}: ${inputValue}`;
 
-    const reportTypeName = reportType === "detailed" ? "Detailed" : "Summary";
+    let csvContent = "";
+    let headers: string[] = [];
+    let rows: any[] = [];
 
-    link.setAttribute("href", url);
-    link.setAttribute(
-      "download",
-      `SolarProgress_${reportTypeName}_${fileDescriptor}_BillCycle_${billCycleValue}.csv`
-    );
-    link.style.visibility = "hidden";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    setTimeout(() => URL.revokeObjectURL(url), 100);
-  } catch (error) {
-    console.error("Error generating CSV:", error);
-    alert("Failed to export CSV");
-  }
-};
+    if (reportType === "detailed") {
+      headers = [
+        "Region",
+        "Province",
+        "Area",
+        "Account Number",
+        "Net Type",
+        "Description",
+        "Capacity",
+        "From Area",
+        "To Area",
+        "From Net Type",
+        "To Net Type",
+      ];
+
+      // Sort data to match table order
+      const sortedData = [...detailedData].sort((a, b) => {
+        if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
+        if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
+        return a.Area.localeCompare(b.Area);
+      });
+
+      // Build rows - include Region/Province/Area on EVERY row for CSV
+      rows = sortedData.map((item) => [
+        item.Region,
+        item.Province,
+        item.Area,
+        item.AccountNumber,
+        item.NetType,
+        item.Description,
+        item.Capacity,
+        item.FromArea || "",
+        item.ToArea || "",
+        item.FromNetType || "",
+        item.ToNetType || "",
+      ]);
+    } else {
+      headers = [
+        "Region",
+        "Province",
+        "Area",
+        "Description",
+        "Count",
+        "Capacity",
+      ];
+
+      // Sort data to match table order
+      const sortedData = [...summaryData].sort((a, b) => {
+        if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
+        if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
+        return a.Area.localeCompare(b.Area);
+      });
+
+      // Build rows - include Region/Province/Area on EVERY row for CSV
+      rows = sortedData.map((item) => [
+        item.Region,
+        item.Province,
+        item.Area,
+        item.Description,
+        item.Count,
+        item.Capacity,
+      ]);
+    }
+
+    // Build CSV content with proper structure
+    csvContent = [
+      reportTitle,
+      selectionInfo,
+      `Bill Cycle: ${selectedBillCycleDisplay}`,
+      `Generated: ${new Date().toLocaleDateString()}`,
+      "",
+      headers.map((h) => `"${h}"`).join(","),
+      ...rows.map((row) => row.map((cell: any) => `"${cell}"`).join(",")),
+    ].join("\n");
+
+    try {
+      const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+
+      const fileDescriptor =
+        selectedOption === "Entire CEB"
+          ? "EntireCEB"
+          : selectedOption === "Area"
+            ? `${selectedOption}_${selectedAreaName}`
+            : `${selectedOption}_${inputValue}`;
+
+      const reportTypeName = reportType === "detailed" ? "Detailed" : "Summary";
+
+      link.setAttribute("href", url);
+      link.setAttribute(
+        "download",
+        `SolarProgress_${reportTypeName}_${fileDescriptor}_BillCycle_${billCycleValue}.csv`
+      );
+      link.style.visibility = "hidden";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(url), 100);
+    } catch (error) {
+      console.error("Error generating CSV:", error);
+      alert("Failed to export CSV");
+    }
+  };
 
   const printPDF = () => {
     if (!printRef.current) return;
@@ -468,10 +488,10 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
 
   const renderDetailedTable = () => {
     const sortedData = [...detailedData].sort((a, b) => {
-    if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
-    if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
-    return a.Area.localeCompare(b.Area);
-  });
+      if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
+      if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
+      return a.Area.localeCompare(b.Area);
+    });
     // Group data and calculate rowspans
     const groupedData = sortedData.reduce(
       (acc, item, index) => {
@@ -633,10 +653,10 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
 
   const renderSummaryTable = () => {
     const sortedData = [...summaryData].sort((a, b) => {
-    if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
-    if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
-    return a.Area.localeCompare(b.Area);
-  });
+      if (a.Region !== b.Region) return a.Region.localeCompare(b.Region);
+      if (a.Province !== b.Province) return a.Province.localeCompare(b.Province);
+      return a.Area.localeCompare(b.Area);
+    });
     // Group data and calculate rowspans
     const groupedData = sortedData.reduce(
       (acc, item, index) => {
@@ -929,10 +949,11 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                   className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
                   required
                 >
-                  <option value="Area">Area</option>
-                  <option value="Province">Province</option>
-                  <option value="Division">Division</option>
-                  <option value="Entire CEB">Entire CEB</option>
+                  {allowedCategories.map((cat) => (
+                    <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                      {cat === "Region" ? "Division" : cat}
+                    </option>
+                  ))}
                 </select>
               </div>
 
@@ -968,13 +989,22 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                     </div>
                   ) : areaError ? (
                     <div className="text-red-500 text-xs py-2">{areaError}</div>
+                  ) : locked["Area"] ? (
+                    <select
+                      disabled
+                      value={locked["Area"].code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Area"].code}>
+                        {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                      </option>
+                    </select>
                   ) : (
                     <select
                       value={inputValue}
                       onChange={(e) => {
                         const selectedAreaCode = e.target.value;
                         setInputValue(selectedAreaCode);
-                        // Find and store the area name
                         const selectedArea = areas.find(
                           (area) => area.AreaCode === selectedAreaCode
                         );
@@ -1030,6 +1060,16 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                     <div className="text-red-500 text-xs py-2">
                       {provinceError}
                     </div>
+                  ) : locked["Province"] ? (
+                    <select
+                      disabled
+                      value={locked["Province"].code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Province"].code}>
+                        {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                      </option>
+                    </select>
                   ) : (
                     <select
                       value={inputValue}
@@ -1040,10 +1080,7 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                     >
                       <option value="">Select Province</option>
                       {provinces.map((province) => (
-                        <option
-                          key={province.ProvinceCode}
-                          value={province.ProvinceCode}
-                        >
+                        <option key={province.ProvinceCode} value={province.ProvinceCode}>
                           {formatProvinceOption(province)}
                         </option>
                       ))}
@@ -1085,6 +1122,14 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                     <div className="text-red-500 text-xs py-2">
                       {divisionError}
                     </div>
+                  ) : locked["Region"] ? (
+                    <select
+                      disabled
+                      value={locked["Region"].code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                    </select>
                   ) : (
                     <select
                       value={inputValue}
@@ -1095,10 +1140,7 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                     >
                       <option value="">Select Division</option>
                       {divisions.map((division) => (
-                        <option
-                          key={division.RegionCode}
-                          value={division.RegionCode}
-                        >
+                        <option key={division.RegionCode} value={division.RegionCode}>
                           {formatDivisionOption(division)}
                         </option>
                       ))}
@@ -1110,15 +1152,14 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
               {/* Bill Cycle Dropdown*/}
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isLoadingBillCycles ||
-                    billCycleError !== null ||
-                    (selectedOption === "Area" && !inputValue) ||
-                    (selectedOption === "Province" && !inputValue) ||
-                    (selectedOption === "Division" && !inputValue)
+                  className={`text-xs font-medium mb-1 ${isLoadingBillCycles ||
+                      billCycleError !== null ||
+                      (selectedOption === "Area" && !inputValue) ||
+                      (selectedOption === "Province" && !inputValue) ||
+                      (selectedOption === "Division" && !inputValue)
                       ? "text-gray-400" // light gray when disabled
                       : maroon
-                  }`}
+                    }`}
                 >
                   Select Bill Cycle:
                 </label>
@@ -1165,15 +1206,14 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                       );
                     }}
                     className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
-            ${
-              isLoadingBillCycles ||
-              billCycleError !== null ||
-              (selectedOption === "Area" && !inputValue) ||
-              (selectedOption === "Province" && !inputValue) ||
-              (selectedOption === "Division" && !inputValue)
-                ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                : "border-gray-300"
-            }`}
+            ${isLoadingBillCycles ||
+                        billCycleError !== null ||
+                        (selectedOption === "Area" && !inputValue) ||
+                        (selectedOption === "Province" && !inputValue) ||
+                        (selectedOption === "Division" && !inputValue)
+                        ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                        : "border-gray-300"
+                      }`}
                     required
                     disabled={
                       isLoadingBillCycles ||
@@ -1194,11 +1234,10 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
               {/* Report Type Dropdown */}
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isReportTypeDisabled()
+                  className={`text-xs font-medium mb-1 ${isReportTypeDisabled()
                       ? "text-gray-400" // light gray when disabled
                       : maroon
-                  }`}
+                    }`}
                 >
                   Select Report Type:
                 </label>
@@ -1206,11 +1245,10 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                   value={reportType}
                   onChange={(e) => setReportType(e.target.value)}
                   className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent
-                                ${
-                                  isReportTypeDisabled()
-                                    ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                                    : "border-gray-300"
-                                }`}
+                                ${isReportTypeDisabled()
+                      ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      : "border-gray-300"
+                    }`}
                   required
                   disabled={isReportTypeDisabled()}
                 >
@@ -1226,9 +1264,8 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
               <button
                 type="submit"
                 className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow
-                            ${maroonGrad} text-white ${
-                  loading ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
-                }`}
+                            ${maroonGrad} text-white ${loading ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
+                  }`}
                 disabled={loading || isReportTypeDisabled() || !reportType}
               >
                 {loading ? (
@@ -1278,8 +1315,8 @@ const SolarProgressClarificationOrdinary: React.FC = () => {
                 {selectedOption === "Entire CEB"
                   ? "Entire CEB"
                   : selectedOption === "Area"
-                  ? `${selectedOption}: ${selectedAreaName}`
-                  : `${selectedOption}: ${inputValue}`}{" "}
+                    ? `${selectedOption}: ${selectedAreaName}`
+                    : `${selectedOption}: ${inputValue}`}{" "}
                 | Bill Cycle: {selectedBillCycleDisplay}
               </p>
             </div>


### PR DESCRIPTION
## What this does

Restricts what geographic scope a user can view across the Solar Information reports, based on their organizational level (Chairman / Region / Province / Area), matching CEB's org hierarchy. This is the frontend counterpart to the backend region/province filtering added earlier (see linked PRs).

## Access rules

| Level | Sees categories | Locked to |
|---|---|---|
| 80 (Chairman) | Area, Province, Region, Entire CEB | Nothing — full access |
| 70 (Region) | Area, Province, Region | Own region only; Province/Area lists scoped to that region |
| 60 (Province) | Area, Province | Own province only; Area list scoped to that province |
| 50 (Area) | Area | Own area only |

## Where the access data comes from

On login, `LoginCard` calls the existing `/misapi/api/billmap/{epfNo}` endpoint and merges the returned `LevelNo` + `BillMap` code/`CompanyName` into the user object as `Level` and the matching `RegionCode`/`ProvinceCode`/`AreaCode` + name fields, based on level. This is stored via `UserContext` (backed by `localStorage`, as before).

## Shared hook: `useReportScope`

A single hook (`src/hooks/useReportScope.ts`) derives `allowedCategories` and a `locked` map (which category, if any, is locked and to what value) from the user's `Level`. Every report below just calls this hook rather than re-implementing the level logic.

## Reports updated

- `RoofTopSolarInputData`
- `SolarPVCapacityInformation`
- `SolarPaymentRetail`
- `SolarConnectionDetailsRetail`
- `SolarConnectionDetailsBulk`
- `SolarPaymentBulk`
- `SolarProgressClarificationOrdinary`
- `SolarProgressClarificationBulk`
- `SolarPVBilling`

Each report now:
- Renders only the Category options the user's level allows.
- Shows a disabled, single-option dropdown for whichever tier is locked, instead of the full list.
- Passes `?regionCode=` / `?provCode=` on its areas/province fetch calls when the user is scoped, so the dropdown options   themselves are also correctly scoped (not just the top-level category).

`SolarCustomerInformation` was left untouched — it has no Area/Province/Region dropdowns (it's a direct account-number lookup), so no scoping applies there.

## Bug fixed during this work

An early version of the `SolarConnectionDetailsBulk` change put the `locked` object directly in a `useEffect` dependency array. Since `locked` is a new object reference on every render, this caused an infinite fetch loop that flooded the backend and produced intermittent 500s — including on unrelated, unfiltered requests caught in the crossfire. Fixed by depending on primitive values (`user.Level`, `user.RegionCode`, etc.) instead of the object itself, applied consistently across all reports.

## Testing done

Verified all 9 reports with 5 real EPF numbers covering each level (Chairman, 
two Region accounts, two Province accounts), using a temporary localStorage 
override for testing without needing real passwords:
- Correct categories shown per level
- Correct dropdown locked to the correct single value per level
- Correct `?regionCode=`/`?provCode=` scoping confirmed via Network tab
- Confirmed no repeated/looping requests after the dependency-array fix