### PR TITLE
Add level-based (Chairman/Region/Province/Area) access control to General reports

### DIFF
--- a/src/mainTopics/general/Arreasposition.tsx
+++ b/src/mainTopics/general/Arreasposition.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   areaCode: string;
@@ -52,7 +54,7 @@ const parseNumber = (value: any): number => {
 };
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 const billCycleToLabel = (cycle: number): string => {
   const baseYear = 1988;
@@ -73,27 +75,30 @@ const billCycleToShortLabel = (cycle: number): string => {
 };
 
 const AreasPosition: React.FC = () => {
-  const maroon     = "text-[#7A0000]";
+  const maroon = "text-[#7A0000]";
   const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
 
-  const [areas, setAreas]                     = useState<Area[]>([]);
+  const [areas, setAreas] = useState<Area[]>([]);
   const [billCycleOptions, setBillCycleOptions] = useState<string[]>([]);
 
-  const [selectedArea, setSelectedArea]           = useState("");
+  const [selectedArea, setSelectedArea] = useState("");
   const [selectedBillCycle, setSelectedBillCycle] = useState("");
 
-  const [loadingAreas, setLoadingAreas]   = useState(false);
+  const [loadingAreas, setLoadingAreas] = useState(false);
   const [loadingCycles, setLoadingCycles] = useState(false);
   const [loadingReport, setLoadingReport] = useState(false);
 
-  const [areaError, setAreaError]     = useState<string | null>(null);
-  const [cycleError, setCycleError]   = useState<string | null>(null);
+  const [areaError, setAreaError] = useState<string | null>(null);
+  const [cycleError, setCycleError] = useState<string | null>(null);
   const [reportError, setReportError] = useState<string | null>(null);
 
-  const [reportData, setReportData]             = useState<AreasPositionRow[]>([]);
+  const [reportData, setReportData] = useState<AreasPositionRow[]>([]);
   const [resolvedBillCycle, setResolvedBillCycle] = useState("");
   const [selectedAreaName, setSelectedAreaName] = useState("");
-  const [hasSearched, setHasSearched]           = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const { user } = useUser();
+  const { locked } = useReportScope();
 
   const selectCls =
     "w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent";
@@ -104,7 +109,13 @@ const AreasPosition: React.FC = () => {
       setLoadingAreas(true);
       setAreaError(null);
       try {
-        const response = await apiFetch<any[]>(`/misapi/api/ordinary/areas`);
+        let url = "/misapi/api/ordinary/areas";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          url += `?provCode=${locked["Province"].code}`;
+        }
+        const response = await apiFetch<any[]>(url);
         if (response.errorMessage) {
           setAreaError(response.errorMessage);
         } else if (response.data && Array.isArray(response.data)) {
@@ -124,7 +135,7 @@ const AreasPosition: React.FC = () => {
       }
     };
     fetchAreas();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // ── 2. Fetch max bill cycle when area changes ──────────────────────────────
   useEffect(() => {
@@ -182,14 +193,23 @@ const AreasPosition: React.FC = () => {
     fetchMaxCycle();
   }, [selectedArea]);
 
+  useEffect(() => {
+    if (locked["Area"]) {
+      setSelectedArea(locked["Area"].code);
+      setSelectedAreaName(
+        locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code
+      );
+    }
+  }, [user.Level, user.AreaCode, user.AreaName]);
+
   // ── 3. Fetch report ────────────────────────────────────────────────────────
   const fetchReport = useCallback(async () => {
     if (!selectedArea || !selectedBillCycle) return;
 
-    const areaCodeSnapshot  = selectedArea;
+    const areaCodeSnapshot = selectedArea;
     const billCycleSnapshot = selectedBillCycle;
-    const areaObj           = areas.find((a) => a.areaCode === areaCodeSnapshot);
-    const areaNameSnapshot  = areaObj?.areaName ?? areaCodeSnapshot;
+    const areaObj = areas.find((a) => a.areaCode === areaCodeSnapshot);
+    const areaNameSnapshot = areaObj?.areaName ?? areaCodeSnapshot;
 
     setLoadingReport(true);
     setReportError(null);
@@ -206,7 +226,7 @@ const AreasPosition: React.FC = () => {
 
       const raw = reportResponse.data as any;
 
-      let rows: any[]          = [];
+      let rows: any[] = [];
       let returnedCycle: string = billCycleSnapshot;
 
       if (Array.isArray(raw)) {
@@ -232,11 +252,11 @@ const AreasPosition: React.FC = () => {
 
       const mappedRows: AreasPositionRow[] = rows
         .map((item: any) => ({
-          readerCode:   String(item.ReaderCode    ?? item.readerCode    ?? ""),
-          monthlyBill:  String(item.Charge        ?? item.charge        ?? "0.00"),
-          totalBalance: String(item.CrntBalance   ?? item.crntBalance   ?? item.CurrentBalance ?? item.currentBalance ?? "0.00"),
-          ratio:        String(item.Ratio         ?? item.ratio         ?? "0.00"),
-          noOfAccounts: String(item.ReaderCount   ?? item.readerCount   ?? "0"),
+          readerCode: String(item.ReaderCode ?? item.readerCode ?? ""),
+          monthlyBill: String(item.Charge ?? item.charge ?? "0.00"),
+          totalBalance: String(item.CrntBalance ?? item.crntBalance ?? item.CurrentBalance ?? item.currentBalance ?? "0.00"),
+          ratio: String(item.Ratio ?? item.ratio ?? "0.00"),
+          noOfAccounts: String(item.ReaderCount ?? item.readerCount ?? "0"),
         }))
         // Defensive filter: drop phantom reader groups with zero charge AND
         // zero balance (e.g. unassigned reader codes '0' / '01'). The backend
@@ -262,8 +282,8 @@ const AreasPosition: React.FC = () => {
 
   // ── Derived totals ─────────────────────────────────────────────────────────
   const totalMonthlyBill = reportData.reduce((s, r) => s + parseNumber(r.monthlyBill), 0);
-  const totalBalance     = reportData.reduce((s, r) => s + parseNumber(r.totalBalance), 0);
-  const totalAccounts    = reportData.reduce((s, r) => s + parseNumber(r.noOfAccounts), 0);
+  const totalBalance = reportData.reduce((s, r) => s + parseNumber(r.totalBalance), 0);
+  const totalAccounts = reportData.reduce((s, r) => s + parseNumber(r.noOfAccounts), 0);
 
   // Short bill-cycle label used in exports, e.g. "452-Apr"
   const resolvedBillCycleShort = resolvedBillCycle
@@ -294,15 +314,15 @@ const AreasPosition: React.FC = () => {
     ];
 
     const header = ["Reader Code", "Charge (Monthly Bill)", "Current Balance", "Ratio", "Reader Count"];
-    const rows   = reportData.map((r) => [r.readerCode, r.monthlyBill, r.totalBalance, r.ratio, r.noOfAccounts]);
+    const rows = reportData.map((r) => [r.readerCode, r.monthlyBill, r.totalBalance, r.ratio, r.noOfAccounts]);
     const totalRow = ["Total", totalMonthlyBill.toFixed(2), totalBalance.toFixed(2), "", totalAccounts.toString()];
 
     const csv = [...metaRows, header, ...rows, totalRow]
       .map((row) => row.map(escapeCsv).join(","))
       .join("\r\n");
 
-    const link   = document.createElement("a");
-    link.href    = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
     link.download = `ArrearsPosition_${selectedArea}_${resolvedBillCycleShort || resolvedBillCycle}.csv`;
     link.style.visibility = "hidden";
     document.body.appendChild(link);
@@ -312,7 +332,7 @@ const AreasPosition: React.FC = () => {
 
   const handleExportPdf = () => {
     if (!reportData.length) { setReportError("No data to export."); return; }
-    const title    = "Arrears Position \u2013 Meter Reader Wise";
+    const title = "Arrears Position \u2013 Meter Reader Wise";
     const rowsHtml = reportData.map((r) => `<tr>
       <td style="border:1px solid #ddd;padding:4px 6px;text-align:center;font-size:10px">${escapeCsv(r.readerCode)}</td>
       <td style="border:1px solid #ddd;padding:4px 6px;text-align:right;font-size:10px">${r.monthlyBill}</td>
@@ -386,6 +406,16 @@ const AreasPosition: React.FC = () => {
                   <div className="w-full px-2 py-1.5 text-xs border border-red-300 rounded-md bg-red-50 text-red-600">
                     {areaError}
                   </div>
+                ) : locked["Area"] ? (
+                  <select
+                    disabled
+                    value={locked["Area"].code}
+                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                  >
+                    <option value={locked["Area"].code}>
+                      {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                    </option>
+                  </select>
                 ) : (
                   <select
                     value={selectedArea}
@@ -398,7 +428,7 @@ const AreasPosition: React.FC = () => {
                     <option value="">Select Area</option>
                     {areas.map((area) => (
                       <option key={area.areaCode} value={area.areaCode}>
-                        {area.areaCode} - {area.areaName}
+                        {area.areaCode} – {area.areaName}
                       </option>
                     ))}
                   </select>
@@ -431,9 +461,8 @@ const AreasPosition: React.FC = () => {
                     value={selectedBillCycle}
                     onChange={(e) => setSelectedBillCycle(e.target.value)}
                     disabled={!selectedArea}
-                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                      !selectedArea ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
-                    }`}
+                    className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${!selectedArea ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
+                      }`}
                   >
                     {billCycleOptions.map((cycle) => (
                       <option key={cycle} value={cycle}>

--- a/src/mainTopics/general/LargestCus.tsx
+++ b/src/mainTopics/general/LargestCus.tsx
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from "react";
 import { FaArrowLeft, FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   AreaCode: string;
@@ -92,12 +94,15 @@ const LargestCus: React.FC = () => {
   const [reportError, setReportError] = useState<string | null>(null);
   const [, setRawResponse] = useState<any>(null);
 
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
+
   const printRef = useRef<HTMLDivElement>(null);
 
   const columnTitle =
     selectedOption === "Area" ? "Area" :
-    selectedOption === "Province" ? "Province" :
-    selectedOption === "Division" ? "Region" : "Area / Province / Region";
+      selectedOption === "Province" ? "Province" :
+        selectedOption === "Division" ? "Region" : "Area / Province / Region";
 
   const showConsumption = apiType === "LargestCustomers";
   const showOutstanding = apiType === "LargestOutstandingCustomers";
@@ -108,7 +113,13 @@ const LargestCus: React.FC = () => {
       setIsLoadingAreas(true);
       setAreaError(null);
       try {
-        const res = await fetch("/misapi/api/ordinary/areas", { headers: { Accept: "application/json" } });
+        let url = "/misapi/api/ordinary/areas";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          url += `?provCode=${locked["Province"].code}`;
+        }
+        const res = await fetch(url, { headers: { Accept: "application/json" } });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setAreas(data.data || []);
@@ -119,14 +130,18 @@ const LargestCus: React.FC = () => {
       }
     };
     fetchAreas();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   useEffect(() => {
     const fetchProvinces = async () => {
       setIsLoadingProvinces(true);
       setProvinceError(null);
       try {
-        const res = await fetch("/misapi/api/ordinary/province", { headers: { Accept: "application/json" } });
+        let url = "/misapi/api/ordinary/province";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        }
+        const res = await fetch(url, { headers: { Accept: "application/json" } });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setProvinces(data.data || []);
@@ -137,7 +152,7 @@ const LargestCus: React.FC = () => {
       }
     };
     fetchProvinces();
-  }, []);
+  }, [user.Level, user.RegionCode]);
 
   useEffect(() => {
     const fetchDivisions = async () => {
@@ -156,6 +171,18 @@ const LargestCus: React.FC = () => {
     };
     fetchDivisions();
   }, []);
+
+  useEffect(() => {
+    const key = selectedOption === "Division" ? "Region" : selectedOption;
+    const lock = locked[key as keyof typeof locked];
+    if (lock) {
+      setInputValue(lock.code);
+      const label = lock.name ? `${lock.code} - ${lock.name}` : lock.code;
+      if (key === "Area") setSelectedAreaName(label);
+      else if (key === "Province") setSelectedProvinceName(label);
+      else if (key === "Region") setSelectedRegionName(label);
+    }
+  }, [selectedOption, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
   useEffect(() => {
     const fetchBillCycles = async () => {
@@ -448,10 +475,11 @@ const LargestCus: React.FC = () => {
                   }}
                   className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000]"
                 >
-                  <option value="Area">Area</option>
-                  <option value="Province">Province</option>
-                  <option value="Division">Division (Region)</option>
-                  <option value="Entire CEB">Entire CEB</option>
+                  {allowedCategories.map((cat) => (
+                    <option key={cat} value={cat === "Region" ? "Division" : cat}>
+                      {cat === "Region" ? "Division (Region)" : cat}
+                    </option>
+                  ))}
                 </select>
               </div>
 
@@ -462,7 +490,17 @@ const LargestCus: React.FC = () => {
                   </label>
 
                   {selectedOption === "Area" &&
-                    (isLoadingAreas ? (
+                    (locked["Area"] ? (
+                      <select
+                        disabled
+                        value={locked["Area"].code}
+                        className="w-full px-3 py-2 text-sm border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      >
+                        <option value={locked["Area"].code}>
+                          {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                        </option>
+                      </select>
+                    ) : isLoadingAreas ? (
                       <div className="py-2.5 text-gray-500">Loading areas...</div>
                     ) : areaError ? (
                       <div className="text-red-600 py-2.5 text-xs">{areaError}</div>
@@ -488,7 +526,17 @@ const LargestCus: React.FC = () => {
                     ))}
 
                   {selectedOption === "Province" &&
-                    (isLoadingProvinces ? (
+                    (locked["Province"] ? (
+                      <select
+                        disabled
+                        value={locked["Province"].code}
+                        className="w-full px-3 py-2 text-sm border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      >
+                        <option value={locked["Province"].code}>
+                          {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                        </option>
+                      </select>
+                    ) : isLoadingProvinces ? (
                       <div className="py-2.5 text-gray-500">Loading provinces...</div>
                     ) : provinceError ? (
                       <div className="text-red-600 py-2.5 text-xs">{provinceError}</div>
@@ -514,7 +562,15 @@ const LargestCus: React.FC = () => {
                     ))}
 
                   {selectedOption === "Division" &&
-                    (isLoadingDivisions ? (
+                    (locked["Region"] ? (
+                      <select
+                        disabled
+                        value={locked["Region"].code}
+                        className="w-full px-3 py-2 text-sm border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      >
+                        <option value={locked["Region"].code}>{locked["Region"].code}</option>
+                      </select>
+                    ) : isLoadingDivisions ? (
                       <div className="py-2.5 text-gray-500">Loading divisions...</div>
                     ) : divisionError ? (
                       <div className="text-red-600 py-2.5 text-xs">{divisionError}</div>
@@ -568,9 +624,8 @@ const LargestCus: React.FC = () => {
               <button
                 type="submit"
                 disabled={loading || !billCycleValue}
-                className={`px-8 py-2.5 rounded-lg font-medium text-white shadow-md ${maroonGrad} transition ${
-                  loading ? "opacity-60 cursor-not-allowed" : "hover:brightness-110"
-                }`}
+                className={`px-8 py-2.5 rounded-lg font-medium text-white shadow-md ${maroonGrad} transition ${loading ? "opacity-60 cursor-not-allowed" : "hover:brightness-110"
+                  }`}
               >
                 {loading ? "Loading..." : `Generate ${apiType} Report (Top 50)`}
               </button>
@@ -669,12 +724,12 @@ const LargestCus: React.FC = () => {
                           {selectedOption === "Area"
                             ? selectedAreaName
                             : selectedOption === "Province"
-                            ? selectedProvinceName
-                            : selectedOption === "Division"
-                            ? selectedRegionName
-                            : selectedOption === "Entire CEB"
-                            ? "Entire CEB"
-                            : cust.area || cust.province || cust.region || "—"}
+                              ? selectedProvinceName
+                              : selectedOption === "Division"
+                                ? selectedRegionName
+                                : selectedOption === "Entire CEB"
+                                  ? "Entire CEB"
+                                  : cust.area || cust.province || cust.region || "—"}
                         </td>
                         <td className="px-5 py-3">{cust.tariffCategory}</td>
                       </tr>

--- a/src/mainTopics/general/ListOfGovernmentAccounts.tsx
+++ b/src/mainTopics/general/ListOfGovernmentAccounts.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -56,13 +58,13 @@ const formatConsumption = (value: any): string =>
 // API base — all requests go through /misapi
 // ─────────────────────────────────────────────────────────────────────────────
 const API = {
-  areas:           () => `/misapi/api/ordinary/areas`,
-  departments:     () => `/misapi/api/government-accounts/departments`,
-  maxBillCycle:    (areaCode: string) =>
+  areas: () => `/misapi/api/ordinary/areas`,
+  departments: () => `/misapi/api/government-accounts/departments`,
+  maxBillCycle: (areaCode: string) =>
     `/misapi/api/billsmry/prn_dat_1/billcycle/max?areaCode=${encodeURIComponent(areaCode)}`,
-  reportByArea:    (billCycle: string, areaCode: string) =>
+  reportByArea: (billCycle: string, areaCode: string) =>
     `/misapi/api/government-accounts/area?billCycle=${encodeURIComponent(billCycle)}&areaCode=${encodeURIComponent(areaCode)}`,
-  reportByDept:    (billCycle: string, areaCode: string, departmentCode: string) =>
+  reportByDept: (billCycle: string, areaCode: string, departmentCode: string) =>
     `/misapi/api/government-accounts/department?billCycle=${encodeURIComponent(billCycle)}&areaCode=${encodeURIComponent(areaCode)}&departmentCode=${encodeURIComponent(departmentCode)}`,
 };
 
@@ -70,34 +72,37 @@ const API = {
 // Component
 // ─────────────────────────────────────────────────────────────────────────────
 const ListOfGovernmentAccounts: React.FC = () => {
-  const maroon     = "text-[#7A0000]";
+  const maroon = "text-[#7A0000]";
   const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
 
   // ── Data ───────────────────────────────────────────────────────────────────
-  const [areas,       setAreas]       = useState<Area[]>([]);
+  const [areas, setAreas] = useState<Area[]>([]);
   const [departments, setDepartments] = useState<Department[]>([]);
 
   // ── Form ───────────────────────────────────────────────────────────────────
-  const [selectedArea,       setSelectedArea]       = useState("");
+  const [selectedArea, setSelectedArea] = useState("");
   const [selectedDepartment, setSelectedDepartment] = useState("");
 
   // ── Loading ────────────────────────────────────────────────────────────────
-  const [loadingAreas,  setLoadingAreas]  = useState(false);
-  const [loadingDepts,  setLoadingDepts]  = useState(false);
+  const [loadingAreas, setLoadingAreas] = useState(false);
+  const [loadingDepts, setLoadingDepts] = useState(false);
   const [loadingReport, setLoadingReport] = useState(false);
-  const [loadingMode,   setLoadingMode]   = useState<ReportMode>(null);
+  const [loadingMode, setLoadingMode] = useState<ReportMode>(null);
 
   // ── Errors ─────────────────────────────────────────────────────────────────
-  const [areaError,   setAreaError]   = useState("");
-  const [deptError,   setDeptError]   = useState("");
+  const [areaError, setAreaError] = useState("");
+  const [deptError, setDeptError] = useState("");
   const [reportError, setReportError] = useState("");
 
   // ── Report ─────────────────────────────────────────────────────────────────
-  const [reportData,       setReportData]       = useState<GovernmentAccount[]>([]);
-  const [hasSearched,      setHasSearched]      = useState(false);
+  const [reportData, setReportData] = useState<GovernmentAccount[]>([]);
+  const [hasSearched, setHasSearched] = useState(false);
   const [activeReportMode, setActiveReportMode] = useState<ReportMode>(null);
   const [selectedAreaName, setSelectedAreaName] = useState("");
   const [selectedDeptName, setSelectedDeptName] = useState("");
+
+  const { user } = useUser();
+  const { locked } = useReportScope();
 
   // ── 1. Fetch areas ─────────────────────────────────────────────────────────
   useEffect(() => {
@@ -105,7 +110,13 @@ const ListOfGovernmentAccounts: React.FC = () => {
       setLoadingAreas(true);
       setAreaError("");
       try {
-        const res  = await fetch(API.areas(), { headers: { Accept: "application/json" } });
+        let url = API.areas();
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          url += `?provCode=${locked["Province"].code}`;
+        }
+        const res = await fetch(url, { headers: { Accept: "application/json" } });
         const json = await res.json();
         const data = json?.data ?? json?.Data ?? json ?? [];
         if (!Array.isArray(data) || data.length === 0) {
@@ -122,7 +133,16 @@ const ListOfGovernmentAccounts: React.FC = () => {
       }
     };
     run();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
+
+  useEffect(() => {
+    if (locked["Area"]) {
+      setSelectedArea(locked["Area"].code);
+      setSelectedAreaName(
+        locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code
+      );
+    }
+  }, [user.Level, user.AreaCode, user.AreaName]);
 
   // ── 2. Fetch departments ───────────────────────────────────────────────────
   useEffect(() => {
@@ -130,7 +150,7 @@ const ListOfGovernmentAccounts: React.FC = () => {
       setLoadingDepts(true);
       setDeptError("");
       try {
-        const res  = await fetch(API.departments(), { headers: { Accept: "application/json" } });
+        const res = await fetch(API.departments(), { headers: { Accept: "application/json" } });
         const json = await res.json();
         const data = json?.data ?? json?.Data ?? json ?? [];
         if (!Array.isArray(data) || data.length === 0) {
@@ -139,12 +159,12 @@ const ListOfGovernmentAccounts: React.FC = () => {
         setDepartments(data.map((item: any) => ({
           departmentCode:
             item.DepartmentCode ?? item.departmentCode ??
-            item.Code           ?? item.code           ??
-            item.DeptCode       ?? item.deptCode       ?? "",
+            item.Code ?? item.code ??
+            item.DeptCode ?? item.deptCode ?? "",
           departmentName:
             item.DepartmentName ?? item.departmentName ??
-            item.Name           ?? item.name           ??
-            item.DeptName       ?? item.deptName       ?? "",
+            item.Name ?? item.name ??
+            item.DeptName ?? item.deptName ?? "",
         })));
       } catch (err: any) {
         setDeptError(err.message ?? "Failed to load departments.");
@@ -162,10 +182,10 @@ const ListOfGovernmentAccounts: React.FC = () => {
     try {
       const r = await fetch(url, { headers: { Accept: "application/json" } });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const j  = await r.json();
-      const n  = j?.data ?? j?.Data ?? j ?? null;
+      const j = await r.json();
+      const n = j?.data ?? j?.Data ?? j ?? null;
       const bc = String(
-        n?.billCycle    ?? n?.BillCycle    ??
+        n?.billCycle ?? n?.BillCycle ??
         n?.MaxBillCycle ?? n?.maxBillCycle ?? n ?? ""
       ).trim();
       if (bc) return bc;
@@ -181,8 +201,8 @@ const ListOfGovernmentAccounts: React.FC = () => {
     if (!selectedArea || !mode) return;
     if (mode === "department" && !selectedDepartment) return;
 
-    const areaSnap     = selectedArea;
-    const deptSnap     = selectedDepartment;
+    const areaSnap = selectedArea;
+    const deptSnap = selectedDepartment;
     const areaNameSnap = areas.find(a => a.areaCode === areaSnap)?.areaName ?? areaSnap;
     const deptNameSnap =
       mode === "department"
@@ -220,13 +240,13 @@ const ListOfGovernmentAccounts: React.FC = () => {
       // Do this BEFORE checking errorMessage — some backends return a warning
       // message in the envelope even when valid data rows are present.
       let rows: any[] = [];
-      if      (Array.isArray(json))               rows = json;
-      else if (Array.isArray(json?.data))          rows = json.data;
-      else if (Array.isArray(json?.Data))          rows = json.Data;
+      if (Array.isArray(json)) rows = json;
+      else if (Array.isArray(json?.data)) rows = json.data;
+      else if (Array.isArray(json?.Data)) rows = json.Data;
       else if (Array.isArray(json?.data?.records)) rows = json.data.records;
-      else if (Array.isArray(json?.records))       rows = json.records;
-      else if (Array.isArray(json?.result))        rows = json.result;
-      else if (Array.isArray(json?.Result))        rows = json.Result;
+      else if (Array.isArray(json?.records)) rows = json.records;
+      else if (Array.isArray(json?.result)) rows = json.result;
+      else if (Array.isArray(json?.Result)) rows = json.Result;
 
       console.log("[GOV] rows:", rows.length, rows[0] ? Object.keys(rows[0]) : "—");
 
@@ -246,31 +266,31 @@ const ListOfGovernmentAccounts: React.FC = () => {
       const mapped: GovernmentAccount[] = rows.map((item: any) => ({
         accountNumber:
           String(item.AccountNumber ?? item.accountNumber ??
-                 item.AccountNo     ?? item.accountNo     ?? ""),
+            item.AccountNo ?? item.accountNo ?? ""),
         customerName:
           String(item.CustomerName ?? item.customerName ??
-                 item.Customer     ?? item.customer      ?? ""),
+            item.Customer ?? item.customer ?? ""),
         address:
           String(
             item.Address ?? item.address ??
             [item.Address1, item.Address2, item.Address3].filter(Boolean).join(", ") ?? ""
           ),
         currentBalance: formatCurrency(
-          item.CurrentBalance     ?? item.currentBalance  ??
-          item.CurrentCharge      ?? item.currentCharge   ??
+          item.CurrentBalance ?? item.currentBalance ??
+          item.CurrentCharge ?? item.currentCharge ??
           item["Current Balance"] ?? 0
         ),
         kwhCharge: formatKwh(
-          item.KwhCharge      ?? item.kwhCharge     ??
-          item.KWHCharge      ?? item["kWh Charge"] ?? 0
+          item.KwhCharge ?? item.kwhCharge ??
+          item.KWHCharge ?? item["kWh Charge"] ?? 0
         ),
         averageConsumption: formatConsumption(
-          item.AverageConsumption    ?? item.averageConsumption ??
-          item.AvgConsumption        ?? item["Average Consumption"] ?? 0
+          item.AverageConsumption ?? item.averageConsumption ??
+          item.AvgConsumption ?? item["Average Consumption"] ?? 0
         ),
-        areaName:       item.AreaName       ?? item.areaName       ?? areaNameSnap,
+        areaName: item.AreaName ?? item.areaName ?? areaNameSnap,
         departmentName: item.DepartmentName ?? item.departmentName ?? deptNameSnap,
-        billCycle:      item.BillCycle      ?? item.billCycle      ?? maxBillCycle,
+        billCycle: item.BillCycle ?? item.billCycle ?? maxBillCycle,
       }));
 
       setReportData(mapped);
@@ -286,23 +306,22 @@ const ListOfGovernmentAccounts: React.FC = () => {
       setLoadingReport(false);
       setLoadingMode(null);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedArea, selectedDepartment, areas, departments]);
 
   // ── Totals ─────────────────────────────────────────────────────────────────
   const totalBalance = reportData.reduce((s, r) => s + parseNumber(r.currentBalance), 0);
-  const totalKwh     = reportData.reduce((s, r) => s + parseNumber(r.kwhCharge),      0);
+  const totalKwh = reportData.reduce((s, r) => s + parseNumber(r.kwhCharge), 0);
 
   // ── UI helpers ─────────────────────────────────────────────────────────────
   const selectCls =
     "w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent";
 
   const Placeholder = ({ msg, error }: { msg: string; error?: boolean }) => (
-    <div className={`w-full px-2 py-1.5 text-xs border rounded-md ${
-      error
+    <div className={`w-full px-2 py-1.5 text-xs border rounded-md ${error
         ? "border-red-300 bg-red-50 text-red-600"
         : "border-gray-300 bg-gray-50 text-gray-500"
-    }`}>{msg}</div>
+      }`}>{msg}</div>
   );
 
   const Spinner = () => (
@@ -341,7 +360,7 @@ const ListOfGovernmentAccounts: React.FC = () => {
 
   const handleExportPdf = () => {
     if (!reportData.length) return;
-    const title    = `List of Government Accounts — ${activeReportMode === "area" ? "Area Report" : "Department Report"}`;
+    const title = `List of Government Accounts — ${activeReportMode === "area" ? "Area Report" : "Department Report"}`;
     const subtitle = `Area: ${selectedAreaName}${activeReportMode === "department" && selectedDeptName ? ` | Department: ${selectedDeptName}` : ""}`;
     const rowsHtml = reportData.map(r => `<tr>
       <td style="border:1px solid #ddd;padding:4px 6px;font-size:10px">${escapeCsv(r.accountNumber)}</td>
@@ -409,6 +428,16 @@ const ListOfGovernmentAccounts: React.FC = () => {
                   <Placeholder msg="Loading areas…" />
                 ) : areaError ? (
                   <Placeholder msg={areaError} error />
+                ) : locked["Area"] ? (
+                  <select
+                    disabled
+                    value={locked["Area"].code}
+                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                  >
+                    <option value={locked["Area"].code}>
+                      {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                    </option>
+                  </select>
                 ) : (
                   <select
                     value={selectedArea}

--- a/src/mainTopics/general/ListingofCustomers.tsx
+++ b/src/mainTopics/general/ListingofCustomers.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -15,15 +17,15 @@ interface FilterOption {
 }
 
 interface FiltersData {
-  BillCycle?: string;            billCycle?: string;
-  Tariffs?: FilterOption[];      tariffs?: FilterOption[];
+  BillCycle?: string; billCycle?: string;
+  Tariffs?: FilterOption[]; tariffs?: FilterOption[];
   Transformers?: FilterOption[]; transformers?: FilterOption[];
-  Phases?: FilterOption[];       phases?: FilterOption[];
+  Phases?: FilterOption[]; phases?: FilterOption[];
   ConnectionTypes?: FilterOption[]; connectionTypes?: FilterOption[];
-  ReaderCodes?: FilterOption[];  readerCodes?: FilterOption[];
-  DailyPacks?: FilterOption[];   dailyPacks?: FilterOption[];
-  Depots?: FilterOption[];       depots?: FilterOption[];
-  ErrorMessage?: string;         errorMessage?: string;
+  ReaderCodes?: FilterOption[]; readerCodes?: FilterOption[];
+  DailyPacks?: FilterOption[]; dailyPacks?: FilterOption[];
+  Depots?: FilterOption[]; depots?: FilterOption[];
+  ErrorMessage?: string; errorMessage?: string;
 }
 
 interface CustomerRecord {
@@ -69,49 +71,52 @@ const ListingOfCustomers: React.FC = () => {
   const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
 
   // ── Core state ─────────────────────────────────────────────────────────────
-  const [areaCode,  setAreaCode]  = useState("");
+  const [areaCode, setAreaCode] = useState("");
   const [billCycle, setBillCycle] = useState("");
-  const [loading,   setLoading]   = useState(false);
+  const [loading, setLoading] = useState(false);
 
   // ── Data ───────────────────────────────────────────────────────────────────
-  const [areas,   setAreas]   = useState<Area[]>([]);
+  const [areas, setAreas] = useState<Area[]>([]);
   const [filters, setFilters] = useState<FiltersData | null>(null);
 
   // ── Loading flags ──────────────────────────────────────────────────────────
-  const [isLoadingAreas,   setIsLoadingAreas]   = useState(false);
+  const [isLoadingAreas, setIsLoadingAreas] = useState(false);
   const [isLoadingFilters, setIsLoadingFilters] = useState(false);
-  const [filtersLoaded,    setFiltersLoaded]    = useState(false);
+  const [filtersLoaded, setFiltersLoaded] = useState(false);
 
   // ── Error state ────────────────────────────────────────────────────────────
-  const [areaError,   setAreaError]   = useState<string | null>(null);
+  const [areaError, setAreaError] = useState<string | null>(null);
   const [filterError, setFilterError] = useState<string | null>(null);
   const [reportError, setReportError] = useState<string | null>(null);
 
   // ── Report state ───────────────────────────────────────────────────────────
-  const [reportData,       setReportData]       = useState<CustomerRecord[]>([]);
-  const [reportVisible,    setReportVisible]    = useState(false);
+  const [reportData, setReportData] = useState<CustomerRecord[]>([]);
+  const [reportVisible, setReportVisible] = useState(false);
   const [selectedAreaName, setSelectedAreaName] = useState("");
 
   // ── Filter field state ─────────────────────────────────────────────────────
   const [useTariff, setUseTariff] = useState(false); const [tariff, setTariff] = useState("");
-  const [useTrans,  setUseTrans]  = useState(false); const [trans,  setTrans]  = useState("");
-  const [usePhase,  setUsePhase]  = useState(false); const [phase,  setPhase]  = useState("");
-  const [useConn,   setUseConn]   = useState(false); const [conn,   setConn]   = useState("");
+  const [useTrans, setUseTrans] = useState(false); const [trans, setTrans] = useState("");
+  const [usePhase, setUsePhase] = useState(false); const [phase, setPhase] = useState("");
+  const [useConn, setUseConn] = useState(false); const [conn, setConn] = useState("");
   const [useReader, setUseReader] = useState(false); const [reader, setReader] = useState("");
-  const [usePack,   setUsePack]   = useState(false); const [pack,   setPack]   = useState("");
-  const [useDepot,  setUseDepot]  = useState(false); const [depot,  setDepot]  = useState("");
+  const [usePack, setUsePack] = useState(false); const [pack, setPack] = useState("");
+  const [useDepot, setUseDepot] = useState(false); const [depot, setDepot] = useState("");
 
-  const [useBal,  setUseBal]  = useState(false);
-  const [balOp,   setBalOp]   = useState<Operator>("=");
-  const [balAmt,  setBalAmt]  = useState("");
+  const [useBal, setUseBal] = useState(false);
+  const [balOp, setBalOp] = useState<Operator>("=");
+  const [balAmt, setBalAmt] = useState("");
 
-  const [usePay,  setUsePay]  = useState(false);
-  const [payOp,   setPayOp]   = useState<Operator>("=");
+  const [usePay, setUsePay] = useState(false);
+  const [payOp, setPayOp] = useState<Operator>("=");
   const [payDate, setPayDate] = useState("");
 
-  const [useArr,  setUseArr]  = useState(false);
-  const [arrOp,   setArrOp]   = useState<Operator>(">=");
-  const [arrPos,  setArrPos]  = useState("1");
+  const [useArr, setUseArr] = useState(false);
+  const [arrOp, setArrOp] = useState<Operator>(">=");
+  const [arrPos, setArrPos] = useState("1");
+
+  const { user } = useUser();
+  const { locked } = useReportScope();
 
   const printRef = useRef<HTMLDivElement>(null);
 
@@ -119,7 +124,13 @@ const ListingOfCustomers: React.FC = () => {
   useEffect(() => {
     setIsLoadingAreas(true);
     setAreaError(null);
-    fetch("/misapi/api/bulk/areas", { headers: { Accept: "application/json" } })
+    let url = "/misapi/api/bulk/areas";
+    if (locked["Region"]?.code) {
+      url += `?regionCode=${locked["Region"].code}`;
+    } else if (locked["Province"]?.code) {
+      url += `?provCode=${locked["Province"].code}`;
+    }
+    fetch(url, { headers: { Accept: "application/json" } })
       .then(async r => {
         if (!r.ok) throw new Error(`HTTP ${r.status}: ${r.statusText}`);
         try { return await r.json(); }
@@ -128,7 +139,17 @@ const ListingOfCustomers: React.FC = () => {
       .then(d => setAreas(d.data || []))
       .catch(e => setAreaError(e.message))
       .finally(() => setIsLoadingAreas(false));
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
+
+
+  useEffect(() => {
+    if (locked["Area"]) {
+      setAreaCode(locked["Area"].code);
+      setSelectedAreaName(
+        locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code
+      );
+    }
+  }, [user.Level, user.AreaCode, user.AreaName]);
 
   // ── 2. When area changes → get bill cycle → get filters ───────────────────
   useEffect(() => {
@@ -206,14 +227,14 @@ const ListingOfCustomers: React.FC = () => {
               const fData = fJson?.data ?? fJson?.Data ?? null;
               if (fData && !cancelled) {
                 const norm: FiltersData = {
-                  billCycle:       fData.BillCycle       ?? fData.billCycle,
-                  tariffs:         fData.Tariffs         ?? fData.tariffs         ?? [],
-                  transformers:    fData.Transformers    ?? fData.transformers    ?? [],
-                  phases:          fData.Phases          ?? fData.phases          ?? [],
+                  billCycle: fData.BillCycle ?? fData.billCycle,
+                  tariffs: fData.Tariffs ?? fData.tariffs ?? [],
+                  transformers: fData.Transformers ?? fData.transformers ?? [],
+                  phases: fData.Phases ?? fData.phases ?? [],
                   connectionTypes: fData.ConnectionTypes ?? fData.connectionTypes ?? [],
-                  readerCodes:     fData.ReaderCodes     ?? fData.readerCodes     ?? [],
-                  dailyPacks:      fData.DailyPacks      ?? fData.dailyPacks      ?? [],
-                  depots:          fData.Depots          ?? fData.depots          ?? [],
+                  readerCodes: fData.ReaderCodes ?? fData.readerCodes ?? [],
+                  dailyPacks: fData.DailyPacks ?? fData.dailyPacks ?? [],
+                  depots: fData.Depots ?? fData.depots ?? [],
                 };
                 setFilters(norm);
               }
@@ -246,15 +267,15 @@ const ListingOfCustomers: React.FC = () => {
   // ── Reset all filter checkboxes and values ─────────────────────────────────
   const resetFilters = () => {
     setUseTariff(false); setTariff("");
-    setUseTrans(false);  setTrans("");
-    setUsePhase(false);  setPhase("");
-    setUseConn(false);   setConn("");
+    setUseTrans(false); setTrans("");
+    setUsePhase(false); setPhase("");
+    setUseConn(false); setConn("");
     setUseReader(false); setReader("");
-    setUsePack(false);   setPack("");
-    setUseDepot(false);  setDepot("");
-    setUseBal(false);    setBalAmt(""); setBalOp("=");
-    setUsePay(false);    setPayDate(""); setPayOp("=");
-    setUseArr(false);    setArrPos("1"); setArrOp(">=");
+    setUsePack(false); setPack("");
+    setUseDepot(false); setDepot("");
+    setUseBal(false); setBalAmt(""); setBalOp("=");
+    setUsePay(false); setPayDate(""); setPayOp("=");
+    setUseArr(false); setArrPos("1"); setArrOp(">=");
   };
 
   // ── Totals ─────────────────────────────────────────────────────────────────
@@ -283,31 +304,31 @@ const ListingOfCustomers: React.FC = () => {
       useArrearsPosition: useArr,
     };
 
-    if (useTariff && tariff)   payload.tariff = tariff;
-    if (useTrans  && trans)    payload.transformer = trans;
-    if (usePhase  && phase)    payload.phase = phase;
-    if (useConn   && conn)     payload.connectionType = conn;
-    if (useReader && reader)   payload.readerCode = reader;
-    if (usePack   && pack)     payload.dailyPackNo = pack;
-    if (useDepot  && depot)    payload.depot = depot;
-    if (useBal    && balAmt) {
+    if (useTariff && tariff) payload.tariff = tariff;
+    if (useTrans && trans) payload.transformer = trans;
+    if (usePhase && phase) payload.phase = phase;
+    if (useConn && conn) payload.connectionType = conn;
+    if (useReader && reader) payload.readerCode = reader;
+    if (usePack && pack) payload.dailyPackNo = pack;
+    if (useDepot && depot) payload.depot = depot;
+    if (useBal && balAmt) {
       payload.balanceOperator = balOp;
-      payload.balanceAmount   = balAmt;
+      payload.balanceAmount = balAmt;
     }
     if (usePay && payDate) {
       payload.lastPaymentOperator = payOp;
-      payload.lastPaymentDate     = payDate;
+      payload.lastPaymentDate = payDate;
     }
     if (useArr && arrPos) {
-      payload.arrearsOperator  = arrOp;
-      payload.arrearsPosition  = arrPos;
+      payload.arrearsOperator = arrOp;
+      payload.arrearsPosition = arrPos;
     }
 
     try {
-      const res  = await fetch("/misapi/api/listing-of-customers/report", {
-        method:  "POST",
+      const res = await fetch("/misapi/api/listing-of-customers/report", {
+        method: "POST",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body:    JSON.stringify(payload),
+        body: JSON.stringify(payload),
       });
 
       const text = await res.text();
@@ -337,16 +358,16 @@ const ListingOfCustomers: React.FC = () => {
   // ── CSV export ─────────────────────────────────────────────────────────────
   const downloadCSV = () => {
     const headers = [
-      "Acct. Number","Meter Numbers","Customer Name","Address","Tariff",
-      "Current Depot","Transformer","Reader Code","KWh Charge","Current Balance",
-      "No. of Phase","Connection Type","Daily Pack No.","Walk Seq","KVA Rating",
+      "Acct. Number", "Meter Numbers", "Customer Name", "Address", "Tariff",
+      "Current Depot", "Transformer", "Reader Code", "KWh Charge", "Current Balance",
+      "No. of Phase", "Connection Type", "Daily Pack No.", "Walk Seq", "KVA Rating",
     ];
     const rows = reportData.map(r => [
       r.AccountNumber, r.MeterNumbers, r.CustomerName, r.Address, r.Tariff,
       r.CurrentDepot, r.Transformer, r.ReaderCode, r.KwhCharge, r.CurrentBalance,
       r.NoOfPhase, r.ConnectionType, r.DailyPackNo, r.WalkSeq, r.KvaRating,
     ]);
-    const totals = ["TOTAL","","","","","","","",fmt(totalKwh),fmt(totalBal),"","","","",""];
+    const totals = ["TOTAL", "", "", "", "", "", "", "", fmt(totalKwh), fmt(totalBal), "", "", "", "", ""];
     const csv = [
       [`Listing of Customers`],
       [`Area: ${selectedAreaName}`, `Bill Cycle: ${billCycle}`],
@@ -383,13 +404,13 @@ const ListingOfCustomers: React.FC = () => {
   };
 
   // ── Resolved option lists ──────────────────────────────────────────────────
-  const oTariff = pick(filters?.Tariffs,         filters?.tariffs,         []);
-  const oTrans  = pick(filters?.Transformers,    filters?.transformers,    []);
-  const oPhase  = pick(filters?.Phases,          filters?.phases,          []);
-  const oConn   = pick(filters?.ConnectionTypes, filters?.connectionTypes, []);
-  const oReader = pick(filters?.ReaderCodes,     filters?.readerCodes,     []);
-  const oPack   = pick(filters?.DailyPacks,      filters?.dailyPacks,      []);
-  const oDepot  = pick(filters?.Depots,          filters?.depots,          []);
+  const oTariff = pick(filters?.Tariffs, filters?.tariffs, []);
+  const oTrans = pick(filters?.Transformers, filters?.transformers, []);
+  const oPhase = pick(filters?.Phases, filters?.phases, []);
+  const oConn = pick(filters?.ConnectionTypes, filters?.connectionTypes, []);
+  const oReader = pick(filters?.ReaderCodes, filters?.readerCodes, []);
+  const oPack = pick(filters?.DailyPacks, filters?.dailyPacks, []);
+  const oDepot = pick(filters?.Depots, filters?.depots, []);
 
   // ready: true only after filters API call succeeded
   const ready = filtersLoaded && !isLoadingFilters;
@@ -506,13 +527,23 @@ const ListingOfCustomers: React.FC = () => {
                   <div className="w-full px-2 py-1.5 text-xs border border-red-300 rounded-md bg-red-50 text-red-600">
                     {areaError}
                   </div>
+                ) : locked["Area"] ? (
+                  <select
+                    disabled
+                    value={locked["Area"].code}
+                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                  >
+                    <option value={locked["Area"].code}>
+                      {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                    </option>
+                  </select>
                 ) : (
                   <select
                     value={areaCode}
                     onChange={e => { setAreaCode(e.target.value); setReportError(null); }}
                     required
                     className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md
-                               focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+               focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
                   >
                     <option value="">Select Area</option>
                     {areas.map(a => (
@@ -717,10 +748,10 @@ const ListingOfCustomers: React.FC = () => {
                   <thead className="bg-gray-100 sticky top-0">
                     <tr>
                       {[
-                        "Acct. Number","Meter Numbers","Customer Name","Address",
-                        "Tariff","Current Depot","Transformer","Reader Code",
-                        "KWh Charge","Current Balance","No. of Phase",
-                        "Connection Type","Daily Pack No.","Walk Seq","KVA Rating",
+                        "Acct. Number", "Meter Numbers", "Customer Name", "Address",
+                        "Tariff", "Current Depot", "Transformer", "Reader Code",
+                        "KWh Charge", "Current Balance", "No. of Phase",
+                        "Connection Type", "Daily Pack No.", "Walk Seq", "KVA Rating",
                       ].map(h => (
                         <th key={h}
                           className="border border-gray-300 px-2 py-1 text-center whitespace-nowrap">

--- a/src/mainTopics/general/RegisteredConsumersForSMSAlerts.tsx
+++ b/src/mainTopics/general/RegisteredConsumersForSMSAlerts.tsx
@@ -1,5 +1,7 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface BillCycleOption {
   display: string;
@@ -60,6 +62,9 @@ const RegisteredConsumersForSMSAlerts = () => {
   const [selectedFromCycleLabel, setSelectedFromCycleLabel] = useState<string>("");
   const [selectedToCycleLabel, setSelectedToCycleLabel] = useState<string>("");
 
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
+
   const printRef = useRef<HTMLDivElement>(null);
 
   const fetchWithErrorHandling = async <T,>(url: string): Promise<T> => {
@@ -87,12 +92,21 @@ const RegisteredConsumersForSMSAlerts = () => {
       setReportError(null);
 
       try {
+        let areasUrl = "/misapi/api/ordinary/areas";
+        let provinceUrl = "/misapi/api/ordinary/province";
+        if (locked["Region"]?.code) {
+          areasUrl += `?regionCode=${locked["Region"].code}`;
+          provinceUrl += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          areasUrl += `?provCode=${locked["Province"].code}`;
+        }
+
         const [cyclesRes, areaRes, provinceRes, divisionRes] = await Promise.all([
           fetchWithErrorHandling<{ data?: { BillCycles?: string[]; MaxBillCycle?: string } }>(
             "/misapi/api/ordinary/areas/billcycle/min"
           ),
-          fetchWithErrorHandling<{ data?: Area[] }>("/misapi/api/ordinary/areas"),
-          fetchWithErrorHandling<{ data?: Province[] }>("/misapi/api/ordinary/province"),
+          fetchWithErrorHandling<{ data?: Area[] }>(areasUrl),
+          fetchWithErrorHandling<{ data?: Province[] }>(provinceUrl),
           fetchWithErrorHandling<{ data?: Division[] }>("/misapi/api/ordinary/region"),
         ]);
 
@@ -131,11 +145,19 @@ const RegisteredConsumersForSMSAlerts = () => {
     };
 
     loadFilters();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   useEffect(() => {
     setTypeCode("");
   }, [reportType]);
+
+  useEffect(() => {
+    const lockKey = reportType === "division" ? "Region" : reportType === "area" ? "Area" : "Province";
+    const lock = locked[lockKey as keyof typeof locked];
+    if (lock) {
+      setTypeCode(lock.code);
+    }
+  }, [reportType, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
   const typeOptions = useMemo(() => {
     if (reportType === "area") {
@@ -421,10 +443,15 @@ const RegisteredConsumersForSMSAlerts = () => {
                   className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
                   disabled={isLoadingFilters || isLoadingReport}
                 >
-                  <option value="area">Area</option>
-                  <option value="province">Province</option>
-                  <option value="division">Division</option>
-                  <option value="entireceb">Entire CEB</option>
+                  {allowedCategories.map((cat) => {
+                    const value = cat === "Region" ? "division" : cat === "Entire CEB" ? "entireceb" : cat.toLowerCase();
+                    const label = cat === "Region" ? "Division" : cat;
+                    return (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    );
+                  })}
                 </select>
               </div>
 
@@ -434,42 +461,56 @@ const RegisteredConsumersForSMSAlerts = () => {
                     {reportType === "area"
                       ? "Select Area:"
                       : reportType === "province"
-                      ? "Select Province:"
-                      : "Select Division:"}
+                        ? "Select Province:"
+                        : "Select Division:"}
                   </label>
-                  <select
-                    value={typeCode}
-                    onChange={(e) => setTypeCode(e.target.value)}
-                    className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-                    disabled={isLoadingFilters || isLoadingReport}
-                    required
-                  >
-                    <option value="">Select Value</option>
-                    {typeOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
+                  {(() => {
+                    const lockKey = reportType === "division" ? "Region" : reportType === "area" ? "Area" : "Province";
+                    const lock = locked[lockKey as keyof typeof locked];
+                    return lock ? (
+                      <select
+                        disabled
+                        value={lock.code}
+                        className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      >
+                        <option value={lock.code}>
+                          {lock.name ? `${lock.code} - ${lock.name}` : lock.code}
+                        </option>
+                      </select>
+                    ) : (
+                      <select
+                        value={typeCode}
+                        onChange={(e) => setTypeCode(e.target.value)}
+                        className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+                        disabled={isLoadingFilters || isLoadingReport}
+                        required
+                      >
+                        <option value="">Select Value</option>
+                        {typeOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    );
+                  })()}
                 </div>
               )}
 
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isBillCycleDisabled() ? "text-gray-400" : maroon
-                  }`}
+                  className={`text-xs font-medium mb-1 ${isBillCycleDisabled() ? "text-gray-400" : maroon
+                    }`}
                 >
                   From Bill Cycle:
                 </label>
                 <select
                   value={fromCycle}
                   onChange={(e) => setFromCycle(e.target.value)}
-                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                    isBillCycleDisabled()
+                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isBillCycleDisabled()
                       ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                       : "border-gray-300"
-                  }`}
+                    }`}
                   disabled={isBillCycleDisabled()}
                   required
                 >
@@ -484,20 +525,18 @@ const RegisteredConsumersForSMSAlerts = () => {
 
               <div className="flex flex-col">
                 <label
-                  className={`text-xs font-medium mb-1 ${
-                    isBillCycleDisabled() ? "text-gray-400" : maroon
-                  }`}
+                  className={`text-xs font-medium mb-1 ${isBillCycleDisabled() ? "text-gray-400" : maroon
+                    }`}
                 >
                   To Bill Cycle:
                 </label>
                 <select
                   value={toCycle}
                   onChange={(e) => setToCycle(e.target.value)}
-                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                    isBillCycleDisabled()
+                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isBillCycleDisabled()
                       ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
                       : "border-gray-300"
-                  }`}
+                    }`}
                   disabled={isBillCycleDisabled()}
                   required
                 >
@@ -514,9 +553,8 @@ const RegisteredConsumersForSMSAlerts = () => {
             <div className="w-full mt-6 flex justify-end">
               <button
                 type="submit"
-                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${
-                  isLoadingReport ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
-                }`}
+                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${isLoadingReport ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
+                  }`}
                 disabled={isLoadingFilters || isLoadingReport}
               >
                 {isLoadingReport ? "Loading..." : "Generate Report"}
@@ -564,33 +602,33 @@ const RegisteredConsumersForSMSAlerts = () => {
             <div className="overflow-x-auto max-h-[calc(100vh-250px)]">
               <div ref={printRef} className="w-fit print-table-wrapper">
                 <table className="sms-alerts-table w-auto min-w-[480px] border-collapse text-xs table-fixed">
-                <thead className="bg-gray-100">
-                  <tr>
-                    <th className="w-60 px-2 py-1.5 text-left border-b border-gray-300">Month</th>
-                    <th className="w-60 px-2 py-1.5 text-right border-l border-b border-gray-300">Registered Count</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-300">
-                  {monthlyCounts.length === 0 ? (
+                  <thead className="bg-gray-100">
                     <tr>
-                      <td colSpan={2} className="px-2 py-2 text-center text-gray-500">
-                        No data available for selected filters.
-                      </td>
+                      <th className="w-60 px-2 py-1.5 text-left border-b border-gray-300">Month</th>
+                      <th className="w-60 px-2 py-1.5 text-right border-l border-b border-gray-300">Registered Count</th>
                     </tr>
-                  ) : (
-                    monthlyCounts.map((row) => (
-                      <tr key={row.BillCycle}>
-                        <td className="px-2 py-1.5 text-gray-700">
-                          {getBillCycleDisplay(row.BillCycle)}
-                        </td>
-                        <td className="px-2 py-1.5 text-right font-medium text-gray-800 border-l border-gray-300">
-                          {row.Count.toLocaleString()}
+                  </thead>
+                  <tbody className="divide-y divide-gray-300">
+                    {monthlyCounts.length === 0 ? (
+                      <tr>
+                        <td colSpan={2} className="px-2 py-2 text-center text-gray-500">
+                          No data available for selected filters.
                         </td>
                       </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
+                    ) : (
+                      monthlyCounts.map((row) => (
+                        <tr key={row.BillCycle}>
+                          <td className="px-2 py-1.5 text-gray-700">
+                            {getBillCycleDisplay(row.BillCycle)}
+                          </td>
+                          <td className="px-2 py-1.5 text-right font-medium text-gray-800 border-l border-gray-300">
+                            {row.Count.toLocaleString()}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>

--- a/src/mainTopics/general/Securitydepositcontractdemandbulk.tsx
+++ b/src/mainTopics/general/Securitydepositcontractdemandbulk.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -93,6 +95,9 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
   const [selectedCategoryName, setSelectedCategoryName] = useState<string>("");
   const [selectedBillCycleDisplay, setSelectedBillCycleDisplay] = useState<string>("");
 
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
+
   const printRef = useRef<HTMLDivElement>(null);
 
   // ── Generic fetch helper ───────────────────────────────────────────────────
@@ -163,7 +168,13 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
       setIsLoadingAreas(true);
       setAreaError(null);
       try {
-        const areaData = await fetchWithErrorHandling(`/misapi/api/bulk/areas`);
+        let url = "/misapi/api/bulk/areas";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          url += `?provCode=${locked["Province"].code}`;
+        }
+        const areaData = await fetchWithErrorHandling(url);
         setAreas(areaData.data || []);
       } catch (err: any) {
         console.error("Error fetching areas:", err);
@@ -173,7 +184,7 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
       }
     };
     fetchAreas();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // ── 3. Fetch provinces on mount ────────────────────────────────────────────
   useEffect(() => {
@@ -181,7 +192,11 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
       setIsLoadingProvinces(true);
       setProvinceError(null);
       try {
-        const provinceData = await fetchWithErrorHandling(`/misapi/api/bulk/province`);
+        let url = "/misapi/api/bulk/province";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        }
+        const provinceData = await fetchWithErrorHandling(url);
         setProvinces(provinceData.data || []);
       } catch (err: any) {
         console.error("Error fetching provinces:", err);
@@ -191,13 +206,19 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
       }
     };
     fetchProvinces();
-  }, []);
+  }, [user.Level, user.RegionCode]);
 
   // ── Reset category value when report category changes ──────────────────────
   useEffect(() => {
-    setCategoryValue("");
-    setSelectedCategoryName("");
-  }, [reportCategory]);
+    const lock = locked[reportCategory as keyof typeof locked];
+    if (lock) {
+      setCategoryValue(lock.code);
+      setSelectedCategoryName(lock.name ? `${lock.code} - ${lock.name}` : lock.code);
+    } else {
+      setCategoryValue("");
+      setSelectedCategoryName("");
+    }
+  }, [reportCategory, user.Level, user.RegionCode, user.ProvinceCode, user.ProvinceName, user.AreaCode, user.AreaName]);
 
   // ── Guards ─────────────────────────────────────────────────────────────────
   const isCategoryValueDisabled = () => {
@@ -381,18 +402,18 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
                 <th className="border border-gray-300 px-2 py-1 text-center">Area</th>
               </>
             )}
-            <th className="border border-gray-300 px-2 py-1 text-center">Acct.<br/>Number</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Acct.<br />Number</th>
             <th className="border border-gray-300 px-2 py-1 text-center">Name</th>
             <th className="border border-gray-300 px-2 py-1 text-center">Address</th>
             <th className="border border-gray-300 px-2 py-1 text-center">City</th>
             <th className="border border-gray-300 px-2 py-1 text-center">Tariff</th>
-            <th className="border border-gray-300 px-2 py-1 text-center">Contract<br/>Demand</th>
-            <th className="border border-gray-300 px-2 py-1 text-center">Security<br/>Deposit</th>
-            <th className="border border-gray-300 px-2 py-1 text-center">Total KWO<br/>Units</th>
-            <th className="border border-gray-300 px-2 py-1 text-center">Total KWD<br/>Units</th>
-            <th className="border border-gray-300 px-2 py-1 text-center">Total<br/>KWP<br/>Units</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Contract<br />Demand</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Security<br />Deposit</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Total KWO<br />Units</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Total KWD<br />Units</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Total<br />KWP<br />Units</th>
             <th className="border border-gray-300 px-2 py-1 text-center">KVA</th>
-            <th className="border border-gray-300 px-2 py-1 text-center">Monthly<br/>Charge</th>
+            <th className="border border-gray-300 px-2 py-1 text-center">Monthly<br />Charge</th>
           </tr>
         </thead>
         <tbody>
@@ -438,7 +459,7 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
       {!reportVisible && (
         <>
           <h1 className={`text-xl font-bold ${maroon} mb-4`}>
-            Security Deposit vs Contract Demand - Bulk
+            Security Deposit and Contract Demand - Bulk
           </h1>
 
           <form onSubmit={handleSubmit} className="space-y-4">
@@ -482,13 +503,15 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
                   value={reportCategory}
                   onChange={e => setReportCategory(e.target.value)}
                   disabled={!billCycle}
-                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                    !billCycle ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
-                  }`}
+                  className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${!billCycle ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
+                    }`}
                   required
                 >
-                  <option value="Area">Area</option>
-                  <option value="Province">Province</option>
+                  {allowedCategories
+                    .filter((cat) => cat === "Area" || cat === "Province")
+                    .map((cat) => (
+                      <option key={cat} value={cat}>{cat}</option>
+                    ))}
                 </select>
               </div>
             </div>
@@ -502,7 +525,17 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
 
                 {reportCategory === "Area" && (
                   <>
-                    {isLoadingAreas ? (
+                    {locked["Area"] ? (
+                      <select
+                        disabled
+                        value={locked["Area"].code}
+                        className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      >
+                        <option value={locked["Area"].code}>
+                          {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                        </option>
+                      </select>
+                    ) : isLoadingAreas ? (
                       <div className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md bg-gray-50 text-gray-500">
                         Loading areas...
                       </div>
@@ -515,9 +548,8 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
                         value={categoryValue}
                         onChange={e => setCategoryValue(e.target.value)}
                         disabled={isCategoryValueDisabled()}
-                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                          isCategoryValueDisabled() ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
-                        }`}
+                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled() ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
+                          }`}
                         required
                       >
                         <option value="">Select Area</option>
@@ -533,7 +565,17 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
 
                 {reportCategory === "Province" && (
                   <>
-                    {isLoadingProvinces ? (
+                    {locked["Province"] ? (
+                      <select
+                        disabled
+                        value={locked["Province"].code}
+                        className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                      >
+                        <option value={locked["Province"].code}>
+                          {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+                        </option>
+                      </select>
+                    ) : isLoadingProvinces ? (
                       <div className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md bg-gray-50 text-gray-500">
                         Loading provinces...
                       </div>
@@ -550,9 +592,8 @@ const SecurityDepositContractDemandBulk: React.FC = () => {
                           setSelectedCategoryName(p ? p.ProvinceName : "");
                         }}
                         disabled={isCategoryValueDisabled()}
-                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${
-                          isCategoryValueDisabled() ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
-                        }`}
+                        className={`w-full px-2 py-1.5 text-xs border rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent ${isCategoryValueDisabled() ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed" : "border-gray-300"
+                          }`}
                         required
                       >
                         <option value="">Select Province</option>


### PR DESCRIPTION
## What this does

Extends the same level-based access restriction already applied to Solar Information reports to the General reports section, using the same shared `useReportScope` hook — no new access logic, just applying the existing pattern to each report's own dropdown structure.

## Reports updated

**Full Category (Area/Province/Region/Entire CEB):**
- `LargestCus`
- `RegisteredConsumersForSMSAlerts`

**Partial Category (Area/Province only — this report never offered a Region/Entire CEB view):**
- `Securitydepositcontractdemandbulk` — Region-level users don't get a "whole region" view here (never existed), but their Area/Province dropdowns are still correctly scoped to their own region.

**Area-only (single Area dropdown, no Category selector):**
- `Arreasposition`
- `ListOfGovernmentAccounts`
- `ListingofCustomers`

Each report now renders only the categories/values its user's level allows, locks the appropriate dropdown to a single value where applicable, and passes `?regionCode=`/`?provCode=` on its areas/province fetch calls so the dropdown options themselves are correctly scoped, not just the top-level category.

## Testing done

Verified each updated report with the 5 real EPF test accounts (Chairman, two Region levels, two Province levels) using the temporary localStorage override, confirming:
- Correct categories/values shown per level
- Correct dropdown locked to the correct value where applicable
- Correct `?regionCode=`/`?provCode=` scoping via Network tab
- No repeated/looping requests (dependency arrays use primitive `user.*` values, not the `locked` object itself, per the fix applied during the Solar reports work)