### PR TITLE
Add level-based (Chairman/Region/Province/Area) access control to Analysis reports

### DIFF
--- a/src/mainTopics/Analysis/AgeAnalysis.tsx
+++ b/src/mainTopics/Analysis/AgeAnalysis.tsx
@@ -20,6 +20,8 @@ import {
   Cell,
   LabelList,
 } from "recharts";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 // Interfaces
 interface Area {
@@ -94,6 +96,9 @@ const AgeAnalysis: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(100); // Show 100 records per page
   const [totalRecords, setTotalRecords] = useState(0);
+
+  const { user } = useUser();
+  const { locked } = useReportScope();
 
   // Constants
   const timePeriods = [
@@ -189,17 +194,21 @@ const AgeAnalysis: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-        // Fetch areas
-        const areaData = await fetchWithErrorHandling("/misapi/api/areas");
-        setAreas(areaData.data || []);
-        if (areaData.data?.length > 0) {
-          setFormData((prev) => ({
-            ...prev,
-            areaCode: areaData.data[0].AreaCode,
-          }));
+        let areasUrl = "/misapi/api/ordinary/areas";
+        if (locked["Region"]?.code) {
+          areasUrl += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          areasUrl += `?provCode=${locked["Province"].code}`;
         }
+        const areaData = await fetchWithErrorHandling(areasUrl);
+        setAreas(areaData.data || []);
+        const defaultAreaCode = locked["Area"]?.code
+          || (areaData.data?.length > 0 ? areaData.data[0].AreaCode : "");
+        setFormData((prev) => ({
+          ...prev,
+          areaCode: defaultAreaCode,
+        }));
 
-        // Fetch bill cycles
         const maxCycleData = await fetchWithErrorHandling(
           "/misapi/api/billcycle/max"
         );
@@ -222,7 +231,7 @@ const AgeAnalysis: React.FC = () => {
     };
 
     fetchData();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // Calculate totals from debtors
   const totals = useMemo(() => {
@@ -525,12 +534,12 @@ const AgeAnalysis: React.FC = () => {
         row.push(
           formatCurrency(
             debtor.Month0 +
-              debtor.Month1 +
-              debtor.Month2 +
-              debtor.Month3 +
-              debtor.Month4 +
-              debtor.Month5 +
-              debtor.Month6
+            debtor.Month1 +
+            debtor.Month2 +
+            debtor.Month3 +
+            debtor.Month4 +
+            debtor.Month5 +
+            debtor.Month6
           ),
           formatCurrency(debtor.Months7_9 + debtor.Months10_12),
           formatCurrency(debtor.Months13_24),
@@ -577,12 +586,12 @@ const AgeAnalysis: React.FC = () => {
         totalsRow.push(
           formatCurrency(
             totals.month0 +
-              totals.month1 +
-              totals.month2 +
-              totals.month3 +
-              totals.month4 +
-              totals.month5 +
-              totals.month6
+            totals.month1 +
+            totals.month2 +
+            totals.month3 +
+            totals.month4 +
+            totals.month5 +
+            totals.month6
           ),
           formatCurrency(totals.months7_9 + totals.months10_12),
           formatCurrency(totals.months13_24),
@@ -598,14 +607,12 @@ const AgeAnalysis: React.FC = () => {
 
     // Create CSV content with proper formatting
     let csvContent = [
-      `"Age Analysis Report - ${
-        customerTypeOptions.find((t) => t.value === formData.custType)?.display
+      `"Age Analysis Report - ${customerTypeOptions.find((t) => t.value === formData.custType)?.display
       } Customers"`,
       `"Bill Cycle: ${getFormattedBillCycle()}"`,
-      `"Area: ${
-        areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName
+      `"Area: ${areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName
       } (${formData.areaCode})"`,
-      
+
       "",
       headers.map((h) => `"${h}"`).join(","),
       ...rows.map((row) => row.map((cell) => `"${cell}"`).join(",")),
@@ -616,9 +623,8 @@ const AgeAnalysis: React.FC = () => {
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `AgeAnalysis_${formData.custType}_Cycle${
-      formData.billCycle
-    }_Area${formData.areaCode}_${new Date().toISOString().slice(0, 10)}.csv`;
+    link.download = `AgeAnalysis_${formData.custType}_Cycle${formData.billCycle
+      }_Area${formData.areaCode}_${new Date().toISOString().slice(0, 10)}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -692,54 +698,52 @@ const AgeAnalysis: React.FC = () => {
         const bgColor = index % 2 === 0 ? "#ffffff" : "#f9f9f9";
         tableHTML += `
           <tr style="background-color: ${bgColor};">
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              debtor.AccountNumber
-            }</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${debtor.AccountNumber
+          }</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${getFullName(
-              debtor
-            )}</td>
+            debtor
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${getFullAddress(
-              debtor
-            )}</td>
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              debtor.TariffCode
-            }</td>
+            debtor
+          )}</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${debtor.TariffCode
+          }</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.OutstandingBalance
-            )}</td>`;
+            debtor.OutstandingBalance
+          )}</td>`;
 
         // Add time period specific data
         if (formData.timePeriod === "0-6") {
           tableHTML += `
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month0
-            )}</td>
+            debtor.Month0
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month1
-            )}</td>
+            debtor.Month1
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month2
-            )}</td>
+            debtor.Month2
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month3
-            )}</td>
+            debtor.Month3
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month4
-            )}</td>
+            debtor.Month4
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month5
-            )}</td>
+            debtor.Month5
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month6
-            )}</td>`;
+            debtor.Month6
+          )}</td>`;
         } else if (formData.timePeriod === "7-12") {
           tableHTML += `
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months7_9
-            )}</td>
+            debtor.Months7_9
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months10_12
-            )}</td>`;
+            debtor.Months10_12
+          )}</td>`;
         } else if (formData.timePeriod === "1-2") {
           tableHTML += `<td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
             debtor.Months13_24
@@ -763,32 +767,32 @@ const AgeAnalysis: React.FC = () => {
         } else if (formData.timePeriod === "All") {
           tableHTML += `
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Month0 +
-                debtor.Month1 +
-                debtor.Month2 +
-                debtor.Month3 +
-                debtor.Month4 +
-                debtor.Month5 +
-                debtor.Month6
-            )}</td>
+            debtor.Month0 +
+            debtor.Month1 +
+            debtor.Month2 +
+            debtor.Month3 +
+            debtor.Month4 +
+            debtor.Month5 +
+            debtor.Month6
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months7_9 + debtor.Months10_12
-            )}</td>
+            debtor.Months7_9 + debtor.Months10_12
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months13_24
-            )}</td>
+            debtor.Months13_24
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months25_36
-            )}</td>
+            debtor.Months25_36
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months37_48
-            )}</td>
+            debtor.Months37_48
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months49_60
-            )}</td>
+            debtor.Months49_60
+          )}</td>
             <td style="border: 1px solid #ddd; padding: 2px 4px; text-align: right; font-size: 10px; vertical-align: top;">${formatCurrency(
-              debtor.Months61Plus
-            )}</td>`;
+            debtor.Months61Plus
+          )}</td>`;
         }
 
         tableHTML += `</tr>`;
@@ -856,14 +860,12 @@ const AgeAnalysis: React.FC = () => {
           </style>
         </head>
         <body>
-          <div class="header">AGE ANALYSIS REPORT - ${
-            customerTypeOptions.find((t) => t.value === formData.custType)
-              ?.display
-          } </div>
+          <div class="header">AGE ANALYSIS REPORT - ${customerTypeOptions.find((t) => t.value === formData.custType)
+        ?.display
+      } </div>
           <div class="subheader">
-            Area: <span class="bold">${
-              areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName
-            } (${formData.areaCode})</span><br>
+            Area: <span class="bold">${areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName
+      } (${formData.areaCode})</span><br>
             Bill Cycle: <span class="bold">${getFormattedBillCycle()}</span><br>
             
           </div>
@@ -928,21 +930,19 @@ const AgeAnalysis: React.FC = () => {
           <div className="flex gap-2">
             <button
               onClick={() => setChartType("bar")}
-              className={`px-3 py-1 rounded text-sm ${
-                chartType === "bar"
+              className={`px-3 py-1 rounded text-sm ${chartType === "bar"
                   ? "bg-blue-600 text-white"
                   : "bg-gray-200 hover:bg-gray-300"
-              }`}
+                }`}
             >
               Bar Chart
             </button>
             <button
               onClick={() => setChartType("pie")}
-              className={`px-3 py-1 rounded text-sm ${
-                chartType === "pie"
+              className={`px-3 py-1 rounded text-sm ${chartType === "pie"
                   ? "bg-blue-600 text-white"
                   : "bg-gray-200 hover:bg-gray-300"
-              }`}
+                }`}
             >
               Pie Chart
             </button>
@@ -1091,11 +1091,10 @@ const AgeAnalysis: React.FC = () => {
           <button
             key={pageNum}
             onClick={() => setCurrentPage(pageNum)}
-            className={`px-2 py-1 text-xs rounded ${
-              currentPage === pageNum
+            className={`px-2 py-1 text-xs rounded ${currentPage === pageNum
                 ? "bg-[#7A0000] text-white"
                 : "bg-gray-200 hover:bg-gray-300"
-            }`}
+              }`}
           >
             {pageNum}
           </button>
@@ -1192,23 +1191,35 @@ const AgeAnalysis: React.FC = () => {
             <label className={`${maroon} text-xs font-medium mb-1`}>
               Select Area:
             </label>
-            <select
-              name="areaCode"
-              value={formData.areaCode}
-              onChange={handleInputChange}
-              className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-              required
-            >
-              {areas.map((area) => (
-                <option
-                  key={area.AreaCode}
-                  value={area.AreaCode}
-                  className="text-xs py-1"
-                >
-                  {area.AreaName} ({area.AreaCode})
+            {locked["Area"] ? (
+              <select
+                disabled
+                value={locked["Area"].code}
+                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+              >
+                <option value={locked["Area"].code}>
+                  {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
                 </option>
-              ))}
-            </select>
+              </select>
+            ) : (
+              <select
+                name="areaCode"
+                value={formData.areaCode}
+                onChange={handleInputChange}
+                className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+                required
+              >
+                {areas.map((area) => (
+                  <option
+                    key={area.AreaCode}
+                    value={area.AreaCode}
+                    className="text-xs py-1"
+                  >
+                    {area.AreaName} ({area.AreaCode})
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
 
           {/* Time Period Dropdown */}
@@ -1249,10 +1260,9 @@ const AgeAnalysis: React.FC = () => {
             className={`
               px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow
               ${maroonGrad} text-white
-              ${
-                reportLoading
-                  ? "opacity-70 cursor-not-allowed"
-                  : "hover:opacity-90"
+              ${reportLoading
+                ? "opacity-70 cursor-not-allowed"
+                : "hover:opacity-90"
               }
             `}
           >
@@ -1429,12 +1439,12 @@ const AgeAnalysis: React.FC = () => {
                       0-6 Months:{" "}
                       {formatCurrency(
                         totals.month0 +
-                          totals.month1 +
-                          totals.month2 +
-                          totals.month3 +
-                          totals.month4 +
-                          totals.month5 +
-                          totals.month6
+                        totals.month1 +
+                        totals.month2 +
+                        totals.month3 +
+                        totals.month4 +
+                        totals.month5 +
+                        totals.month6
                       )}
                     </div>
                     <div>
@@ -1648,12 +1658,12 @@ const AgeAnalysis: React.FC = () => {
                           <td className="border border-gray-300 px-2 py-1 text-right">
                             {formatCurrency(
                               debtor.Month0 +
-                                debtor.Month1 +
-                                debtor.Month2 +
-                                debtor.Month3 +
-                                debtor.Month4 +
-                                debtor.Month5 +
-                                debtor.Month6
+                              debtor.Month1 +
+                              debtor.Month2 +
+                              debtor.Month3 +
+                              debtor.Month4 +
+                              debtor.Month5 +
+                              debtor.Month6
                             )}
                           </td>
                           <td className="border border-gray-300 px-2 py-1 text-right">

--- a/src/mainTopics/Analysis/DebtorsAnalysis.tsx
+++ b/src/mainTopics/Analysis/DebtorsAnalysis.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import DebtorsModal from "../../components/mainTopics/AnalysisDebtors/DebtorsModal";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Area {
   AreaCode: string;
@@ -39,32 +41,37 @@ const DebtorsAnalysis: React.FC = () => {
     '#3B82F6', '#6B7280', '#9CA3AF', '#D97706'
   ];
 
-  // Region codes constant
-  const regionCodes = [
-    { code: "R1", name: "Region 01" },
-    { code: "R2", name: "Region 02" },
-    { code: "R3", name: "Region 03" },
-    { code: "R4", name: "Region 04" }
-  ];
+  // // Region codes constant
+  // const regionCodes = [
+  //   { code: "R1", name: "Region 01" },
+  //   { code: "R2", name: "Region 02" },
+  //   { code: "R3", name: "Region 03" },
+  //   { code: "R4", name: "Region 04" }
+  // ];
 
-  // Province codes constant
-  const provinceCodes = [
-    { code: "1", name: "Western Province North" },
-    { code: "2", name: "Western Province South" },
-    { code: "3", name: "Colombo City" },
-    { code: "4", name: "Northern Province" },
-    { code: "5", name: "Central Province" },
-    { code: "6", name: "Uva Province" },
-    { code: "7", name: "Eastern Province" },
-    { code: "8", name: "North Western Province" },
-    { code: "9", name: "Sabaragamuwa Province" },
-    { code: "A", name: "North Central Province" },
-    { code: "B", name: "Southern Province" },
-    { code: "C", name: "Western Province South 2" },
-    { code: "D", name: "North Western Province 2" },
-    { code: "E", name: "Central Province 2" },
-    { code: "F", name: "Southern Province 2" }
-  ];
+  // // Province codes constant
+  // const provinceCodes = [
+  //   { code: "1", name: "Western Province North" },
+  //   { code: "2", name: "Western Province South" },
+  //   { code: "3", name: "Colombo City" },
+  //   { code: "4", name: "Northern Province" },
+  //   { code: "5", name: "Central Province" },
+  //   { code: "6", name: "Uva Province" },
+  //   { code: "7", name: "Eastern Province" },
+  //   { code: "8", name: "North Western Province" },
+  //   { code: "9", name: "Sabaragamuwa Province" },
+  //   { code: "A", name: "North Central Province" },
+  //   { code: "B", name: "Southern Province" },
+  //   { code: "C", name: "Western Province South 2" },
+  //   { code: "D", name: "North Western Province 2" },
+  //   { code: "E", name: "Central Province 2" },
+  //   { code: "F", name: "Southern Province 2" }
+  // ];
+
+  const { user } = useUser();
+  const { allowedCategories, locked } = useReportScope();
+  const [regionCodes, setRegionCodes] = useState<{ code: string; name: string }[]>([]);
+  const [provinceCodes, setProvinceCodes] = useState<{ code: string; name: string }[]>([]);
 
   // Main state
   const [loading, setLoading] = useState(false);
@@ -158,39 +165,64 @@ const DebtorsAnalysis: React.FC = () => {
 
   // Fetch initial data
   useEffect(() => {
-    const fetchInitialData = async () => {
-      setInitialLoading(true);
-      setError(null);
-      try {
-        // Fetch areas
-        const areaData = await fetchWithErrorHandling("/misapi/api/areas");
-        setAreas(areaData.data || []);
-        if (areaData.data?.length > 0) {
-          setFormData(prev => ({ ...prev, areaCode: areaData.data[0].AreaCode }));
-        }
-
-        // Fetch bill cycles using the same method as AgeAnalysis
-        const maxCycleData = await fetchWithErrorHandling("/misapi/api/billcycle/max");
-        if (maxCycleData.data && maxCycleData.data.BillCycles?.length > 0) {
-          const options = generateBillCycleOptions(
-            maxCycleData.data.BillCycles,
-            maxCycleData.data.MaxBillCycle
-          );
-          setBillCycleOptions(options);
-          setFormData(prev => ({ ...prev, cycle: options[0].code }));
-        } else {
-          setBillCycleOptions([]);
-          setFormData(prev => ({ ...prev, cycle: "" }));
-        }
-      } catch (err: any) {
-        setError("Error loading data: " + (err.message || err.toString()));
-      } finally {
-        setInitialLoading(false);
+  const fetchInitialData = async () => {
+    setInitialLoading(true);
+    setError(null);
+    try {
+      // Fetch all areas (no query param needed — /misapi/api/areas already
+      // returns ProvCode and Region on every row), then filter client-side.
+      const areaData = await fetchWithErrorHandling("/misapi/api/areas");
+      let filteredAreas = areaData.data || [];
+      if (locked["Region"]?.code) {
+        filteredAreas = filteredAreas.filter(
+          (a: any) => a.Region === locked["Region"]!.code
+        );
+      } else if (locked["Province"]?.code) {
+        filteredAreas = filteredAreas.filter(
+          (a: any) => a.ProvCode === locked["Province"]!.code
+        );
       }
-    };
+      setAreas(filteredAreas);
 
-    fetchInitialData();
-  }, []);
+      const regionData = await fetchWithErrorHandling("/misapi/api/ordinary/region");
+      setRegionCodes(
+        (regionData.data || []).map((r: any) => ({ code: r.RegionCode, name: r.RegionCode }))
+      );
+
+      let provinceUrl = "/misapi/api/ordinary/province";
+      if (locked["Region"]?.code) {
+        provinceUrl += `?regionCode=${locked["Region"].code}`;
+      }
+      const provinceData = await fetchWithErrorHandling(provinceUrl);
+      setProvinceCodes(
+        (provinceData.data || []).map((p: any) => ({ code: p.ProvinceCode, name: p.ProvinceName }))
+      );
+
+      const defaultAreaCode = locked["Area"]?.code
+        || (filteredAreas.length > 0 ? filteredAreas[0].AreaCode : "");
+      setFormData(prev => ({ ...prev, areaCode: defaultAreaCode }));
+
+      const maxCycleData = await fetchWithErrorHandling("/misapi/api/billcycle/max");
+      if (maxCycleData.data && maxCycleData.data.BillCycles?.length > 0) {
+        const options = generateBillCycleOptions(
+          maxCycleData.data.BillCycles,
+          maxCycleData.data.MaxBillCycle
+        );
+        setBillCycleOptions(options);
+        setFormData(prev => ({ ...prev, cycle: options[0].code }));
+      } else {
+        setBillCycleOptions([]);
+        setFormData(prev => ({ ...prev, cycle: "" }));
+      }
+    } catch (err: any) {
+      setError("Error loading data: " + (err.message || err.toString()));
+    } finally {
+      setInitialLoading(false);
+    }
+  };
+
+  fetchInitialData();
+}, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   const getCodeLabel = () => {
     const labels = { P: "Province Code", D: "Region Code", A: "Area Code" };
@@ -206,11 +238,11 @@ const DebtorsAnalysis: React.FC = () => {
     if (name === 'option') {
       let defaultAreaCode = "";
       if (value === "D") {
-        defaultAreaCode = "R1"; // Default to first region
+        defaultAreaCode = locked["Region"]?.code || (regionCodes[0]?.code || "");
       } else if (value === "P") {
-        defaultAreaCode = "1"; // Default to first province
-      } else if (value === "A" && areas.length > 0) {
-        defaultAreaCode = areas[0].AreaCode;
+        defaultAreaCode = locked["Province"]?.code || (provinceCodes[0]?.code || "");
+      } else if (value === "A") {
+        defaultAreaCode = locked["Area"]?.code || (areas.length > 0 ? areas[0].AreaCode : "");
       }
 
       setFormData(prev => ({
@@ -744,12 +776,19 @@ const DebtorsAnalysis: React.FC = () => {
     if (formData.option === "E") return null;
 
     if (formData.option === "D") {
-      // Region Code dropdown
+      if (locked["Region"]) {
+        return (
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Region Code</label>
+            <select disabled value={locked["Region"].code} className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed">
+              <option value={locked["Region"].code}>{locked["Region"].code}</option>
+            </select>
+          </div>
+        );
+      }
       return (
         <div>
-          <label className="block text-xs font-medium text-gray-700 mb-1">
-            Region Code
-          </label>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Region Code</label>
           <select
             name="areaCode"
             value={formData.areaCode}
@@ -767,12 +806,21 @@ const DebtorsAnalysis: React.FC = () => {
         </div>
       );
     } else if (formData.option === "P") {
-      // Province Code dropdown
+      if (locked["Province"]) {
+        return (
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Province Code</label>
+            <select disabled value={locked["Province"].code} className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed">
+              <option value={locked["Province"].code}>
+                {locked["Province"].name ? `${locked["Province"].code} - ${locked["Province"].name}` : locked["Province"].code}
+              </option>
+            </select>
+          </div>
+        );
+      }
       return (
         <div>
-          <label className="block text-xs font-medium text-gray-700 mb-1">
-            Province Code
-          </label>
+          <label className="block text-xs font-medium text-gray-700 mb-1">Province Code</label>
           <select
             name="areaCode"
             value={formData.areaCode}
@@ -790,12 +838,21 @@ const DebtorsAnalysis: React.FC = () => {
         </div>
       );
     } else {
-      // Area Code dropdown (for Area option only)
+      if (locked["Area"]) {
+        return (
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">{getCodeLabel()}</label>
+            <select disabled value={locked["Area"].code} className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed">
+              <option value={locked["Area"].code}>
+                {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+              </option>
+            </select>
+          </div>
+        );
+      }
       return (
         <div>
-          <label className="block text-xs font-medium text-gray-700 mb-1">
-            {getCodeLabel()}
-          </label>
+          <label className="block text-xs font-medium text-gray-700 mb-1">{getCodeLabel()}</label>
           <select
             name="areaCode"
             value={formData.areaCode}
@@ -856,10 +913,10 @@ const DebtorsAnalysis: React.FC = () => {
                 className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
                 style={{ maxHeight: '200px', fontSize: '12px' }}
               >
-                <option value="A">Area</option>
-                <option value="D">Region</option>
-                <option value="P">Province</option>
-                <option value="E">All CEB</option>
+                {allowedCategories.includes("Area") && <option value="A">Area</option>}
+                {allowedCategories.includes("Region") && <option value="D">Region</option>}
+                {allowedCategories.includes("Province") && <option value="P">Province</option>}
+                {allowedCategories.includes("Entire CEB") && <option value="E">All CEB</option>}
               </select>
             </div>
 

--- a/src/mainTopics/Analysis/SolarAgeAnalysis.tsx
+++ b/src/mainTopics/Analysis/SolarAgeAnalysis.tsx
@@ -5,6 +5,8 @@ import React, {
   useCallback,
 } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 // Interfaces
 interface Area {
@@ -70,6 +72,9 @@ const SolarAgeAnalysis: React.FC = () => {
   const [reportMode, setReportMode] = useState<"age" | "full" | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 30;
+
+  const { user } = useUser();
+  const { locked } = useReportScope();
 
   // chart removed
 
@@ -177,17 +182,24 @@ const SolarAgeAnalysis: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-        // Fetch areas
-        const areaData = await fetchWithErrorHandling(
-          "/misapi/api/analysis/solar-age/areas"
-        );
-        setAreas(areaData.data || []);
-        if (areaData.data?.length > 0) {
-          setFormData((prev) => ({
-            ...prev,
-            areaCode: areaData.data[0].AreaCode,
-          }));
+        // Fetch areas — switched to the ordinary endpoint, which already
+        // supports region/province scoping and matches the DB connection
+        // this report's actual data queries use.
+        let areasUrl = "/misapi/api/ordinary/areas";
+        if (locked["Region"]?.code) {
+          areasUrl += `?regionCode=${locked["Region"].code}`;
+        } else if (locked["Province"]?.code) {
+          areasUrl += `?provCode=${locked["Province"].code}`;
         }
+        const areaData = await fetchWithErrorHandling(areasUrl);
+        setAreas(areaData.data || []);
+
+        const defaultAreaCode = locked["Area"]?.code
+          || (areaData.data?.length > 0 ? areaData.data[0].AreaCode : "");
+        setFormData((prev) => ({
+          ...prev,
+          areaCode: defaultAreaCode,
+        }));
 
         // Fetch bill cycles from the shared bill cycle API
         // Original implementation (kept commented for reference):
@@ -257,7 +269,7 @@ const SolarAgeAnalysis: React.FC = () => {
     };
 
     fetchData();
-  }, []);
+  }, [user.Level, user.RegionCode, user.ProvinceCode]);
 
   // Calculate age group summary
   const calculateAgeGroupSummary = useCallback(
@@ -464,7 +476,7 @@ const SolarAgeAnalysis: React.FC = () => {
 
     const isFullReport = reportMode === "full";
 
-     // Escape a cell value for CSV.
+    // Escape a cell value for CSV.
     // Long numeric-only strings (e.g. account numbers) are wrapped with ="..."
     // so Excel / WPS Office renders the full number instead of scientific notation.
     // This also maximises the visible column width because the cell content is
@@ -484,40 +496,40 @@ const SolarAgeAnalysis: React.FC = () => {
 
     const headers = isFullReport
       ? [
-          "Account Number",
-          "Name",
-          "Address",
-          "Type",
-          "Initial Agreement Date",
-          "Panel Capacity",
-        ]
+        "Account Number",
+        "Name",
+        "Address",
+        "Type",
+        "Initial Agreement Date",
+        "Panel Capacity",
+      ]
       : [
-          "Account Number",
-          "Name",
-          "Address",
-          "Net Type",
-          "Initial Agreement Date",
-          "Age (Years)",
-        ];
+        "Account Number",
+        "Name",
+        "Address",
+        "Net Type",
+        "Initial Agreement Date",
+        "Age (Years)",
+      ];
 
     const rows = customers.map((customer) =>
       isFullReport
         ? [
-            customer.AccountNumber,
-            customer.Name,
-            customer.Address,
-            customer.NetType,
-            customer.InitialAgreementDate,
-            customer.PanelCapacity || "",
-          ]
+          customer.AccountNumber,
+          customer.Name,
+          customer.Address,
+          customer.NetType,
+          customer.InitialAgreementDate,
+          customer.PanelCapacity || "",
+        ]
         : [
-            customer.AccountNumber,
-            customer.Name,
-            customer.Address,
-            customer.NetType,
-            customer.InitialAgreementDate,
-            customer.AgeInYears?.toString() || "N/A",
-          ]
+          customer.AccountNumber,
+          customer.Name,
+          customer.Address,
+          customer.NetType,
+          customer.InitialAgreementDate,
+          customer.AgeInYears?.toString() || "N/A",
+        ]
     );
 
     // const summaryRows =
@@ -548,9 +560,9 @@ const SolarAgeAnalysis: React.FC = () => {
     //   ),
     // ].join("\n");
 
-        const areaName =
+    const areaName =
       areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName || "";
- 
+
     const lines: string[] = [
       `"Solar Age Analysis Report"`,
       `"Bill Cycle: ${getFormattedBillCycle()}"`,
@@ -564,37 +576,36 @@ const SolarAgeAnalysis: React.FC = () => {
     ];
 
 
-  //   const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-  //   const url = URL.createObjectURL(blob);
-  //   const link = document.createElement("a");
-  //   link.href = url;
-  //   link.download = `SolarAgeAnalysis_Cycle${
-  //     formData.billCycle
-  //   }_Area${formData.areaCode}_${new Date().toISOString().slice(0, 10)}.csv`;
-  //   document.body.appendChild(link);
-  //   link.click();
-  //   document.body.removeChild(link);
-  //   URL.revokeObjectURL(url);
-  // }, [customers, formData, billCycleOptions, areas, ageGroupSummary]);
+    //   const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    //   const url = URL.createObjectURL(blob);
+    //   const link = document.createElement("a");
+    //   link.href = url;
+    //   link.download = `SolarAgeAnalysis_Cycle${
+    //     formData.billCycle
+    //   }_Area${formData.areaCode}_${new Date().toISOString().slice(0, 10)}.csv`;
+    //   document.body.appendChild(link);
+    //   link.click();
+    //   document.body.removeChild(link);
+    //   URL.revokeObjectURL(url);
+    // }, [customers, formData, billCycleOptions, areas, ageGroupSummary]);
 
-  // UTF-8 BOM ensures Excel / WPS Office opens the file with the correct
+    // UTF-8 BOM ensures Excel / WPS Office opens the file with the correct
     // encoding so special characters (e.g. Sinhala names) are not garbled.
     const BOM = "\uFEFF";
     const csvContent = BOM + lines.join("\r\n");
- 
+
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `SolarAgeAnalysis_Cycle${formData.billCycle}_Area${
-      formData.areaCode
-    }_${new Date().toISOString().slice(0, 10)}.csv`;
+    link.download = `SolarAgeAnalysis_Cycle${formData.billCycle}_Area${formData.areaCode
+      }_${new Date().toISOString().slice(0, 10)}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   }, [customers, reportMode, formData, billCycleOptions, areas, ageGroupSummary]);
- 
+
 
   const printPDF = () => {
     if (!customers.length) return;
@@ -623,21 +634,16 @@ const SolarAgeAnalysis: React.FC = () => {
         const bgColor = index % 2 === 0 ? "#ffffff" : "#f9f9f9";
         tableHTML += `
           <tr style="background-color: ${bgColor};">
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              customer.AccountNumber
-            }</td>
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              customer.Name
-            }</td>
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              customer.Address
-            }</td>
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              customer.NetType
-            }</td>
-            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${
-              customer.InitialAgreementDate
-            }</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${customer.AccountNumber
+          }</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${customer.Name
+          }</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${customer.Address
+          }</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${customer.NetType
+          }</td>
+            <td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${customer.InitialAgreementDate
+          }</td>
             ${isFullReport ? `<td style="border: 1px solid #ddd; padding: 2px 4px; font-size: 10px; vertical-align: top;">${customer.PanelCapacity || ""}</td>` : ''}
           </tr>`;
       });
@@ -706,9 +712,8 @@ const SolarAgeAnalysis: React.FC = () => {
         <body>
           <div class="header">SOLAR AGE ANALYSIS REPORT</div>
           <div class="subheader">
-            Area: <span class="bold">${
-              areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName
-            } (${formData.areaCode})</span><br>
+            Area: <span class="bold">${areas.find((a) => a.AreaCode === formData.areaCode)?.AreaName
+      } (${formData.areaCode})</span><br>
             Bill Cycle: <span class="bold">${getFormattedBillCycle()}</span><br>
             Total Customers: <span class="bold">${customers.length}</span><br>
           </div>
@@ -751,36 +756,31 @@ const SolarAgeAnalysis: React.FC = () => {
             <label className={`${maroon} text-xs font-medium mb-1`}>
               Select Area:
             </label>
-            <select
-              name="areaCode"
-              value={formData.areaCode}
-              onChange={handleInputChange}
-              className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
-              required
-            >
-              {areas.map((area) => (
-                <React.Fragment key={area.AreaCode}>
-                  {/* Original display (kept commented):
-                  <option
-                    key={area.AreaCode}
-                    value={area.AreaCode}
-                    className="text-xs py-1"
-                  >
-                    {area.AreaName} ({area.AreaCode})
-                  </option>
-                  */}
-
-                  {/* New display: areaCode - areaName */}
-                  <option
-                    key={area.AreaCode}
-                    value={area.AreaCode}
-                    className="text-xs py-1"
-                  >
+            {locked["Area"] ? (
+              <select
+                disabled
+                value={locked["Area"].code}
+                className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+              >
+                <option value={locked["Area"].code}>
+                  {locked["Area"].name ? `${locked["Area"].code} - ${locked["Area"].name}` : locked["Area"].code}
+                </option>
+              </select>
+            ) : (
+              <select
+                name="areaCode"
+                value={formData.areaCode}
+                onChange={handleInputChange}
+                className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent"
+                required
+              >
+                {areas.map((area) => (
+                  <option key={area.AreaCode} value={area.AreaCode} className="text-xs py-1">
                     {area.AreaCode} - {area.AreaName}
                   </option>
-                </React.Fragment>
-              ))}
-            </select>
+                ))}
+              </select>
+            )}
           </div>
 
           {/* Bill Cycle Dropdown */}
@@ -855,8 +855,8 @@ const SolarAgeAnalysis: React.FC = () => {
               px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow
               ${maroonGrad} text-white
               ${viewLoading || fullReportLoading || !formData.areaCode || !formData.billCycle
-                  ? "opacity-70 cursor-not-allowed"
-                  : "hover:opacity-90"}
+                ? "opacity-70 cursor-not-allowed"
+                : "hover:opacity-90"}
             `}
           >
             {fullReportLoading ? (
@@ -893,11 +893,10 @@ const SolarAgeAnalysis: React.FC = () => {
             return (
               <div
                 key={index}
-                className={`flex items-center justify-between gap-2 rounded border px-2 py-1.5 ${
-                  isSelected
+                className={`flex items-center justify-between gap-2 rounded border px-2 py-1.5 ${isSelected
                     ? "border-[#7A0000] bg-red-50"
                     : "border-gray-200 bg-white"
-                }`}
+                  }`}
               >
                 <div className="text-sm font-medium text-gray-800 leading-none">
                   {item.ageGroup}


### PR DESCRIPTION
## What this does

Extends the existing level-based access restriction (via the shared `useReportScope` hook) to the Analysis section reports.

## Reports updated

- **`DebtorsAnalysis`** 
    - Area/Region/Province/All CEB selector. 
    - Region and Province lists were previously hardcoded arrays with no way to scope them; replaced with real fetched data from `/misapi/api/ordinary/region` and `/misapi/api/ordinary/province` (supports `?regionCode=` filtering). 
    - Areas are fetched from the existing `/misapi/api/areas` and filtered client-side using the `ProvCode`/`Region` fields already present on every area row.
- **`AgeAnalysis`** 
    - Area-only. 
    - Same client-side filtering approach applied to its `/misapi/api/areas` call.
- **`SolarAgeAnalysis`** 
    - Area-only. 
    - Switched its areas source from the bulk-connection `/misapi/api/analysis/solar-age/areas` endpoint to `/misapi/api/ordinary/areas`, which also fixes a pre-existing inconsistency: the report's actual data queries (`SolarAgeAnalysisDao`) use the ordinary connection, but the old areas endpoint was sourcing its dropdown from the bulk connection. 
    - Now both are aligned on ordinary, with proper `?regionCode=`/`?provCode=` scoping.

## Testing done

Verified all 3 updated reports with the 5 real EPF test accounts (Chairman, Region, Province levels) using the temporary localStorage override:
- Correct Analysis Option choices shown per level (`DebtorsAnalysis`)
- Correct dropdown locked/scoped per level across all three reports
- Confirmed `SolarAgeAnalysis` area list now matches the ordinary-connection area set the report actually queries against