### PR TITLE
Add report catalog browsing feature

### DIFF
--- a/src/components/catalog/CategoryCard.tsx
+++ b/src/components/catalog/CategoryCard.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { CheckCircle2, Grid } from "lucide-react";
+import { CATEGORY_CONFIG, DEFAULT_CATEGORY_CONFIG, normalizeCategoryKey } from "../../data/SideBarData";
+
+interface CategoryCardProps {
+  catCode: string;
+  categoryName: string;
+  count: number;
+  isSelected: boolean;
+  onSelect: (catCode: string) => void;
+}
+
+const getCategoryIcon = (categoryName: string, catCode: string) => {
+  if (catCode === "ALL") {
+    return Grid;
+  }
+
+  const normalizedName = normalizeCategoryKey(categoryName || "");
+  const directMatch = CATEGORY_CONFIG[normalizedName];
+  if (directMatch?.icon) {
+    return directMatch.icon;
+  }
+
+  const fallbackMatch = Object.entries(CATEGORY_CONFIG).find(
+    ([key]) => normalizeCategoryKey(key) === normalizedName
+  );
+
+  if (fallbackMatch?.[1]?.icon) {
+    return fallbackMatch[1].icon;
+  }
+
+  return DEFAULT_CATEGORY_CONFIG.icon;
+};
+
+export const CategoryCard: React.FC<CategoryCardProps> = ({
+  catCode,
+  categoryName,
+  count,
+  isSelected,
+  onSelect,
+}) => {
+  const IconComponent = catCode === "ALL" ? Grid : getCategoryIcon(categoryName, catCode);
+
+  return (
+    <div
+      onClick={() => onSelect(catCode)}
+      className={`group relative cursor-pointer rounded-xl p-5 border transition-all duration-300 transform hover:-translate-y-1 hover:shadow-md select-none ${
+        isSelected
+          ? "bg-gradient-to-br from-[#800000]/10 via-[#800000]/5 to-white border-[#800000] shadow-sm ring-1 ring-[#800000]"
+          : "bg-white border-gray-200/80 hover:border-gray-300 shadow-2xs"
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div
+          className={`p-3 rounded-lg transition-colors duration-200 ${
+            isSelected
+              ? "bg-[#800000] text-white"
+              : "bg-gray-100/80 text-gray-600 group-hover:bg-[#800000]/10 group-hover:text-[#800000]"
+          }`}
+        >
+          <IconComponent className="w-5 h-5" />
+        </div>
+
+        {isSelected && (
+          <CheckCircle2 className="w-4 h-4 text-[#800000] animate-in fade-in zoom-in-75" />
+        )}
+      </div>
+
+      <div className="mt-4">
+        <h3
+          className={`text-base font-semibold transition-colors duration-200 ${
+            isSelected ? "text-[#800000]" : "text-gray-800 group-hover:text-[#800000]"
+          }`}
+        >
+          {categoryName}
+        </h3>
+        <p className="text-xs text-gray-500 mt-1 font-medium">
+          {count} {count === 1 ? "Report" : "Reports"}
+        </p>
+      </div>
+
+      <div
+        className={`absolute bottom-0 left-0 right-0 h-0.5 rounded-b-xl transition-all duration-300 ${
+          isSelected ? "bg-[#800000]" : "bg-transparent group-hover:bg-gray-300"
+        }`}
+      />
+    </div>
+  );
+};
+
+export default CategoryCard;

--- a/src/components/catalog/ReportDetails.tsx
+++ b/src/components/catalog/ReportDetails.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import {
+  FileText,
+  CheckCircle,
+  Lock,
+  SlidersHorizontal,
+  Info,
+  ExternalLink,
+} from "lucide-react";
+import { CatalogReportItem } from "../../hooks/useReportCatalog";
+import { SamplePreview } from "./SamplePreview";
+import { useNavigate } from "react-router-dom";
+import { CATEGORY_CONFIG } from "../../data/SideBarData";
+
+interface ReportDetailsProps {
+  report: CatalogReportItem;
+}
+
+const getCategoryPath = (categoryName: string): string => {
+  const norm = (categoryName || "").trim();
+  if (CATEGORY_CONFIG[norm]) {
+    return CATEGORY_CONFIG[norm].path;
+  }
+  const match = Object.entries(CATEGORY_CONFIG).find(
+    ([key]) => key.trim().toLowerCase() === norm.toLowerCase()
+  );
+  if (match) {
+    return match[1].path;
+  }
+  // Default slug fallback
+  const slug = norm
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-");
+  return `/report/${slug || "all reports"}`;
+};
+
+export const ReportDetails: React.FC<ReportDetailsProps> = ({ report }) => {
+  const navigate = useNavigate();
+  const parameters = (report.parameterDescriptions || []).filter(Boolean);
+
+  const handleGoToReport = () => {
+    const targetPath = getCategoryPath(report.categoryName);
+    navigate(targetPath, {
+      state: {
+        selectedSubtopicId: report.repIdNo,
+        reportName: report.reportName,
+      },
+    });
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200/80 shadow-xs overflow-hidden h-full flex flex-col">
+      {/* Header Banner - Application Maroon Theme Color */}
+      <div className="p-6 bg-gradient-to-r from-[#7A0000] via-[#800000] to-[#7A0000] text-white relative overflow-hidden">
+        <div className="relative z-10 space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="px-3 py-1 rounded-full text-xs font-semibold bg-white/15 text-white backdrop-blur-sm border border-white/20">
+              {report.categoryName}
+            </span>
+          </div>
+
+          <h2 className="text-2xl font-bold tracking-tight text-white flex items-center gap-2">
+            <FileText className="w-6 h-6 text-white/90" />
+            <span>{report.reportName}</span>
+          </h2>
+        </div>
+      </div>
+
+      {/* Main Body */}
+      <div className="p-6 space-y-6 flex-1 overflow-y-auto">
+        {/* Access Status Box */}
+        <div className="rounded-xl border transition-all">
+          {report.hasAccess ? (
+            <div className="bg-emerald-50/70 border-emerald-200/80 p-4 rounded-xl flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+              <div className="flex items-start gap-3">
+                <div className="p-2 bg-emerald-600 text-white rounded-lg flex-shrink-0 mt-0.5">
+                  <CheckCircle className="w-5 h-5" />
+                </div>
+                <div>
+                  <h4 className="text-sm font-bold text-emerald-900">
+                    ✅ You have access to this report.
+                  </h4>
+                  <p className="text-xs text-emerald-700 mt-1">
+                    Your assigned role grants permission to generate this report.
+                  </p>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleGoToReport}
+                className="flex items-center gap-2 px-4 py-2 bg-[#800000] hover:bg-[#660000] text-white text-xs font-semibold rounded-lg shadow-xs transition-colors flex-shrink-0 cursor-pointer"
+              >
+                <span>Generate Report</span>
+                <ExternalLink className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ) : (
+            /* No Access Section - Information Only, NO BUTTON */
+            <div className="bg-amber-50/70 border-amber-200/80 p-4 rounded-xl flex items-start gap-3">
+              <div className="p-2 bg-amber-600 text-white rounded-lg flex-shrink-0 mt-0.5">
+                <Lock className="w-5 h-5" />
+              </div>
+              <div>
+                <h4 className="text-sm font-bold text-amber-900">
+                  🔒 You currently do not have permission to generate this report.
+                </h4>
+                <p className="text-xs text-amber-800 mt-1">
+                  You do not currently have permission to access this report. Please contact the system administrator if you require access.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Description Section */}
+        <div className="space-y-2">
+          <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1.5">
+            <Info className="w-4 h-4 text-gray-400" />
+            <span>Description</span>
+          </h3>
+          <p className="text-sm text-gray-700 leading-relaxed bg-gray-50/70 p-4 rounded-xl border border-gray-100 font-normal">
+            {report.description && report.description.trim()
+              ? report.description
+              : "No description provided for this report."}
+          </p>
+        </div>
+
+        {/* Report Parameters Section - ONLY PARAMETERS WITH VALUE = 1 */}
+        {parameters.length > 0 && (
+          <div className="space-y-3">
+            <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1.5">
+              <SlidersHorizontal className="w-4 h-4 text-gray-400" />
+              <span>Configurable Parameters ({parameters.length})</span>
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {parameters.map((param, index) => (
+                <span
+                  key={index}
+                  className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-100 text-gray-800 border border-gray-200/80 shadow-2xs"
+                >
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#800000] mr-2" />
+                  {param}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Sample Output Preview Component */}
+        <SamplePreview report={report} />
+      </div>
+    </div>
+  );
+};
+
+export default ReportDetails;

--- a/src/components/catalog/ReportList.tsx
+++ b/src/components/catalog/ReportList.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { CatalogReportItem } from "../../hooks/useReportCatalog";
+import { ReportListItem } from "./ReportListItem";
+import { Layers } from "lucide-react";
+
+interface ReportListProps {
+  reports: CatalogReportItem[];
+  selectedReportId: string | null;
+  onSelectReport: (report: CatalogReportItem) => void;
+  categoryTitle: string;
+}
+
+export const ReportList: React.FC<ReportListProps> = ({
+  reports,
+  selectedReportId,
+  onSelectReport,
+  categoryTitle,
+}) => {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200/80 shadow-xs overflow-hidden flex flex-col h-full">
+      <div className="p-4 bg-gradient-to-r from-gray-50 to-white border-b border-gray-100 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="p-1.5 bg-[#800000]/10 rounded-md text-[#800000]">
+            <Layers className="w-4 h-4" />
+          </div>
+          <h2 className="text-sm font-bold text-gray-800 tracking-wide uppercase">
+            {categoryTitle}
+          </h2>
+        </div>
+        <span className="text-xs font-semibold px-2.5 py-0.5 rounded-full bg-gray-100 text-gray-600">
+          {reports.length} {reports.length === 1 ? "Report" : "Reports"}
+        </span>
+      </div>
+
+      <div className="p-3 space-y-2 overflow-y-auto max-h-[600px]">
+        {reports.map((report) => (
+          <ReportListItem
+            key={report.repIdNo + "_" + report.repId}
+            report={report}
+            isSelected={
+              selectedReportId === report.repIdNo ||
+              selectedReportId === report.repId ||
+              selectedReportId === report.reportName
+            }
+            onSelect={onSelectReport}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ReportList;

--- a/src/components/catalog/ReportListItem.tsx
+++ b/src/components/catalog/ReportListItem.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { FileText, CheckCircle, Lock, ChevronRight } from "lucide-react";
+import { CatalogReportItem } from "../../hooks/useReportCatalog";
+
+interface ReportListItemProps {
+  report: CatalogReportItem;
+  isSelected: boolean;
+  onSelect: (report: CatalogReportItem) => void;
+}
+
+export const ReportListItem: React.FC<ReportListItemProps> = ({
+  report,
+  isSelected,
+  onSelect,
+}) => {
+  return (
+    <div
+      onClick={() => onSelect(report)}
+      className={`group relative p-3.5 rounded-lg border cursor-pointer transition-all duration-200 flex items-center justify-between ${
+        isSelected
+          ? "bg-gradient-to-r from-[#800000]/10 via-[#800000]/5 to-transparent border-[#800000] text-[#800000] shadow-xs"
+          : "bg-white border-gray-200/80 hover:border-gray-300 hover:bg-gray-50/80 text-gray-700"
+      }`}
+    >
+      <div className="flex items-center gap-3 min-w-0 pr-2">
+        <div
+          className={`p-2 rounded-md transition-colors flex-shrink-0 ${
+            isSelected
+              ? "bg-[#800000] text-white"
+              : "bg-gray-100 text-gray-500 group-hover:bg-gray-200 group-hover:text-gray-700"
+          }`}
+        >
+          <FileText className="w-4 h-4" />
+        </div>
+
+        <div className="min-w-0">
+          <div
+            className={`text-sm font-semibold truncate transition-colors ${
+              isSelected ? "text-[#800000]" : "text-gray-800 group-hover:text-gray-900"
+            }`}
+          >
+            {report.reportName}
+          </div>
+          <div className="text-xs text-gray-400 truncate mt-0.5">
+            {report.categoryName}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {report.hasAccess ? (
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200/60">
+            <CheckCircle className="w-3.5 h-3.5 text-emerald-600" />
+            <span>Accessible</span>
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200/60">
+            <Lock className="w-3.5 h-3.5 text-amber-600" />
+            <span>No Access</span>
+          </span>
+        )}
+
+        <ChevronRight
+          className={`w-4 h-4 transition-transform duration-200 ${
+            isSelected ? "text-[#800000] translate-x-0.5" : "text-gray-300 group-hover:text-gray-400"
+          }`}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ReportListItem;

--- a/src/components/catalog/SamplePreview.tsx
+++ b/src/components/catalog/SamplePreview.tsx
@@ -1,0 +1,233 @@
+import React, { useState, useEffect } from "react";
+import { ImageOff, FileText, ZoomIn, X, Plus, Minus, RotateCcw } from "lucide-react";
+import { CatalogReportItem } from "../../hooks/useReportCatalog";
+
+interface SamplePreviewProps {
+  report: CatalogReportItem;
+}
+
+export const resolveImagePath = (rawPath: unknown): string | null => {
+  if (!rawPath || typeof rawPath !== "string") return null;
+  let path = rawPath.trim();
+  if (!path) return null;
+
+  // 1. Data URLs or Absolute HTTP/HTTPS URLs
+  if (
+    path.startsWith("data:") ||
+    path.startsWith("http://") ||
+    path.startsWith("https://")
+  ) {
+    return path;
+  }
+
+  // Normalize all backslashes to forward slashes
+  path = path.replace(/\\/g, "/");
+
+  // Fix common typo in database sample report paths (e.g. CashSheetRepoet -> CashSheetReport)
+  path = path.replace(/Repoet/gi, "Report");
+
+  // If path contains src/assets
+  if (path.includes("src/assets/")) {
+    const assetPath = path.substring(path.indexOf("src/assets/"));
+    return `/${assetPath}`;
+  }
+
+  // If path contains SampleReports
+  if (path.includes("SampleReports/")) {
+    const samplePath = path.substring(path.indexOf("SampleReports/"));
+    return `/src/assets/${samplePath}`;
+  }
+
+  // Extract filename
+  const filename = path.split("/").pop();
+
+  // If simple filename or ends with image extension
+  if (filename && /\.(png|jpg|jpeg|gif|svg|webp)$/i.test(filename)) {
+    return `/src/assets/SampleReports/${filename}`;
+  }
+
+  // Relative paths starting with assets/
+  if (path.startsWith("assets/")) {
+    return `/src/${path}`;
+  }
+
+  // Absolute paths starting with /
+  if (path.startsWith("/")) {
+    return path;
+  }
+
+  // Default fallback through API prefix
+  return `/misapi/${path}`;
+};
+
+export const SamplePreview: React.FC<SamplePreviewProps> = ({ report }) => {
+  const [imageError, setImageError] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [zoomLevel, setZoomLevel] = useState<number>(1);
+  const resolvedUrl = resolveImagePath(report.path);
+
+  // Reset image error state and modal whenever selected report changes
+  useEffect(() => {
+    setImageError(false);
+    setIsModalOpen(false);
+    setZoomLevel(1);
+  }, [report.repIdNo, report.repId, report.path]);
+
+  // Handle ESC key press to close modal
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsModalOpen(false);
+      }
+    };
+    if (isModalOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "unset";
+    };
+  }, [isModalOpen]);
+
+  const adjustZoom = (delta: number) => {
+    setZoomLevel((prev) => Math.min(3, Math.max(1, Number((prev + delta).toFixed(2)))));
+  };
+
+  return (
+    <>
+      <div className="bg-gradient-to-b from-gray-50/70 to-white border border-gray-200/90 rounded-xl overflow-hidden mt-4">
+        {/* Top Header */}
+        <div className="p-3 bg-gray-100/70 border-b border-gray-200/80 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <FileText className="w-4 h-4 text-gray-500" />
+            <span className="text-xs font-semibold text-gray-700 uppercase tracking-wider">
+              Report Output
+            </span>
+          </div>
+          {resolvedUrl && !imageError && (
+            <span className="text-[11px] text-gray-400 font-medium hidden sm:inline">
+              Click image to enlarge
+            </span>
+          )}
+        </div>
+
+        {/* Output Content */}
+        <div className="p-4 flex items-center justify-center min-h-[200px]">
+          {resolvedUrl && !imageError ? (
+            <div
+              onClick={() => setIsModalOpen(true)}
+              className="group relative w-full flex justify-center cursor-pointer rounded-lg overflow-hidden"
+              title="Click to open enlarged preview"
+            >
+              <img
+                src={resolvedUrl}
+                alt={`${report.reportName} Screenshot`}
+                onError={() => setImageError(true)}
+                className="max-w-full max-h-[500px] object-contain rounded-lg border border-gray-200 shadow-2xs group-hover:opacity-95 transition-opacity"
+              />
+              {/* Subtle hover overlay badge */}
+              <div className="absolute inset-0 bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center text-white font-medium text-xs rounded-lg backdrop-blur-[1px]">
+                <div className="bg-black/70 px-3.5 py-1.5 rounded-full flex items-center gap-1.5 shadow-md">
+                  <ZoomIn className="w-4 h-4" />
+                  <span>Click to Enlarge</span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center p-8 text-center space-y-2 text-gray-400">
+              <div className="p-3 bg-gray-100 rounded-full text-gray-400">
+                <ImageOff className="w-6 h-6" />
+              </div>
+              <p className="text-xs font-medium text-gray-500">
+                Sample report output is not available.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Enlarged Image Lightbox Modal (Constrained to Main Content Area) */}
+      {isModalOpen && resolvedUrl && !imageError && (
+        <div
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setIsModalOpen(false);
+          }}
+          className="fixed top-[80px] left-0 lg:left-64 right-0 bottom-0 z-40 flex items-center justify-center bg-black/75 backdrop-blur-xs p-4 sm:p-6 transition-all duration-200"
+        >
+          <div className="relative max-w-5xl max-h-[85vh] w-full bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col border border-gray-700/30">
+            {/* Modal Header */}
+            <div className="px-5 py-3 bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 text-white flex items-center justify-between border-b border-gray-800 gap-3">
+              <div className="flex items-center gap-2.5 min-w-0 pr-4">
+                <FileText className="w-4 h-4 text-gray-300 flex-shrink-0" />
+                <h3 className="text-sm font-semibold truncate text-gray-100">
+                  {report.reportName} — Sample Preview
+                </h3>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <div className="flex items-center gap-1 rounded-lg border border-white/10 bg-white/10 px-1.5 py-1">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      adjustZoom(-0.25);
+                    }}
+                    className="p-1.5 text-gray-300 hover:text-white rounded-md hover:bg-white/10 transition-colors cursor-pointer"
+                    title="Zoom out"
+                  >
+                    <Minus className="w-4 h-4" />
+                  </button>
+                  <span className="min-w-[46px] text-center text-[11px] font-semibold text-gray-100">
+                    {zoomLevel.toFixed(2)}x
+                  </span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      adjustZoom(0.25);
+                    }}
+                    className="p-1.5 text-gray-300 hover:text-white rounded-md hover:bg-white/10 transition-colors cursor-pointer"
+                    title="Zoom in"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setZoomLevel(1);
+                    }}
+                    className="p-1.5 text-gray-300 hover:text-white rounded-md hover:bg-white/10 transition-colors cursor-pointer"
+                    title="Reset zoom"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(false)}
+                  className="p-1.5 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition-colors cursor-pointer flex-shrink-0"
+                  title="Close preview (Esc)"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+              </div>
+            </div>
+
+            {/* Modal Image Viewport - Zoomable */}
+            <div className="p-4 bg-gray-950/90 flex-1 flex items-center justify-center overflow-auto min-h-[300px]">
+              <img
+                src={resolvedUrl}
+                alt={`${report.reportName} Full Screenshot`}
+                className="max-w-full max-h-[75vh] object-contain rounded-md shadow-lg select-none transition-transform duration-200"
+                style={{ transform: `scale(${zoomLevel})` }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SamplePreview;

--- a/src/components/catalog/SearchBar.tsx
+++ b/src/components/catalog/SearchBar.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Search, X, Filter } from "lucide-react";
+
+interface SearchBarProps {
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  totalResults?: number;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  searchTerm,
+  onSearchChange,
+  totalResults,
+}) => {
+  return (
+    <div className="relative w-full">
+      <div className="relative flex items-center w-full bg-white rounded-xl shadow-xs border border-gray-200/80 hover:border-gray-300 focus-within:border-[#800000] focus-within:ring-2 focus-within:ring-[#800000]/15 transition-all duration-200">
+        <div className="pl-4 text-gray-400 flex items-center pointer-events-none">
+          <Search className="w-5 h-5 text-gray-400" />
+        </div>
+
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search by report name or category name..."
+          className="w-full py-3.5 pl-3 pr-10 text-sm text-gray-800 placeholder-gray-400 bg-transparent focus:outline-none font-normal"
+        />
+
+        {searchTerm && (
+          <button
+            type="button"
+            onClick={() => onSearchChange("")}
+            className="pr-3 text-gray-400 hover:text-gray-600 transition-colors p-1 rounded-full hover:bg-gray-100 cursor-pointer"
+            title="Clear search"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+
+        <div className="hidden sm:flex items-center gap-1.5 pr-4 border-l border-gray-100 pl-3 text-xs text-gray-400 font-medium">
+          <Filter className="w-3.5 h-3.5 text-gray-400" />
+          <span>{totalResults !== undefined ? `${totalResults} found` : "Instant Filter"}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -20,6 +20,8 @@ type User = {
   Common_exception: string | null;
   Errormsg: string | null;
   Logged: boolean;
+  RoleId?: string;
+  Role?: string;
 };
 
 type UserContextType = {

--- a/src/data/SideBarData.ts
+++ b/src/data/SideBarData.ts
@@ -86,7 +86,7 @@ const ROLE_REPORTS_ENDPOINTS = [
   
 ];
 
-const DEFAULT_CATEGORY_CONFIG: CategoryConfig = {
+export const DEFAULT_CATEGORY_CONFIG: CategoryConfig = {
   icon: TbReportAnalytics,
   path: "/report/reports",
 };
@@ -98,9 +98,6 @@ export const CATEGORY_CONFIG: Record<string, CategoryConfig> = {
   Dashboard: { icon: MdDashboard, path: "/dashboard" },
   DashBoard: { icon: MdDashboard, path: "/dashboard" },
   "Main Dashboard": { icon: MdDashboard, path: "/dashboard" },
-  "DB-Dashboard": { icon: MdDashboard, path: "/dashboard" },
-  "DB-DASHBOARD": { icon: MdDashboard, path: "/dashboard" },
-  "Dashboards": { icon: MdDashboard, path: "/dashboard" },
   General: { icon: MdPayment, path: "/report/general" },
   "Customer Details": { icon: RiBankLine, path: "/report/billing-payment" },
   Analysis: { icon: FaBoxes, path: "/report/analysis" },
@@ -128,7 +125,7 @@ export const CATEGORY_CONFIG: Record<string, CategoryConfig> = {
   "Physical Verification - FIFO": { icon: TbReportAnalytics, path: "/report/PhysicalVerification/FIFO" },
 };
 
-const normalizeCategoryKey = (value: string): string =>
+export const normalizeCategoryKey = (value: string): string =>
   value
     .trim()
     .replace(/[\u2013\u2014]/g, "-")

--- a/src/hooks/useReportCatalog.ts
+++ b/src/hooks/useReportCatalog.ts
@@ -1,0 +1,125 @@
+import { useState, useEffect } from "react";
+import { useUser } from "../contexts/UserContext";
+
+export type CatalogReportItem = {
+  path: string;
+  repIdNo: string;
+  repId: string;
+  reportName: string;
+  catCode: string;
+  categoryName: string;
+  description: string;
+  paramList: string;
+  parameterDescriptions: string[];
+  favorite: number;
+  active: number;
+  hasAccess: boolean;
+};
+
+export type CategorySummary = {
+  catCode: string;
+  categoryName: string;
+  totalReports: number;
+};
+
+const getCatalogDisplayName = (item: any): string => {
+  const candidates = [
+    item?.ReportName,
+    item?.reportName,
+    item?.RepName,
+    item?.repname,
+    item?.RepId,
+    item?.repId,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return "";
+};
+
+export const useReportCatalog = () => {
+  const { user } = useUser();
+  const epfNo = user?.Userno || "";
+  const roleId = user?.RoleId || "";
+
+  const [reports, setReports] = useState<CatalogReportItem[]>([]);
+  const [categories, setCategories] = useState<CategorySummary[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const fetchCatalog = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const queryParams = new URLSearchParams();
+        if (epfNo) queryParams.append("epfNo", epfNo);
+        if (roleId) queryParams.append("roleId", roleId);
+
+        const response = await fetch(`/misapi/api/reportcatalog/all?${queryParams.toString()}`, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Server returned status ${response.status}`);
+        }
+
+        const resData = await response.json();
+
+        if (isCancelled) return;
+
+        if (resData?.data?.Reports && Array.isArray(resData.data.Reports) && resData.data.Reports.length > 0) {
+          const apiReports: CatalogReportItem[] = resData.data.Reports.map((item: any) => ({
+            repIdNo: String(item.RepIdNo ?? item.repIdNo ?? ""),
+            repId: String(item.RepId ?? item.repId ?? ""),
+            reportName: getCatalogDisplayName(item),
+            catCode: String(item.CatCode ?? item.catCode ?? ""),
+            categoryName: String(item.CategoryName ?? item.categoryName ?? item.CatCode ?? item.catCode ?? ""),
+            description: String(item.Description ?? item.description ?? ""),
+            paramList: String(item.ParamList ?? item.paramList ?? ""),
+            parameterDescriptions: Array.isArray(item.ParameterDescriptions ?? item.parameterDescriptions)
+              ? (item.ParameterDescriptions ?? item.parameterDescriptions).map((value: any) => String(value ?? "").trim()).filter(Boolean)
+              : [],
+            path: String(item.Path ?? item.path ?? ""),
+            favorite: Number(item.Favorite ?? item.favorite ?? 0),
+            active: Number(item.Active ?? item.active ?? 1),
+            hasAccess: Boolean(item.HasAccess ?? item.hasAccess ?? false),
+          }));
+
+          const apiCategories: CategorySummary[] = (resData.data.Categories || []).map((cat: any) => ({
+            catCode: String(cat.CatCode || cat.catCode || ""),
+            categoryName: String(cat.CategoryName || cat.categoryName || cat.CatCode || ""),
+            totalReports: Number(cat.TotalReports ?? cat.totalReports ?? 0),
+          }));
+
+          setReports(apiReports);
+          setCategories(apiCategories);
+        }
+      } catch (err: any) {
+        if (!isCancelled) {
+          console.warn("Using fallback catalog data due to API notice:", err?.message);
+        }
+      } finally {
+        if (!isCancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchCatalog();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [epfNo, roleId]);
+
+  return { reports, categories, loading, error };
+};

--- a/src/pages/ReportCatalog.tsx
+++ b/src/pages/ReportCatalog.tsx
@@ -1,0 +1,226 @@
+import { useState, useMemo } from "react";
+import { useReportCatalog, CatalogReportItem } from "../hooks/useReportCatalog";
+import SearchBar from "../components/catalog/SearchBar";
+import CategoryCard from "../components/catalog/CategoryCard";
+import ReportList from "../components/catalog/ReportList";
+import ReportDetails from "../components/catalog/ReportDetails";
+import { Library, FolderSearch, Loader2 } from "lucide-react";
+
+export const ReportCatalog = () => {
+  const { reports, categories, loading, error } = useReportCatalog();
+
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [selectedCatCode, setSelectedCatCode] = useState<string>("ALL");
+  const [selectedReport, setSelectedReport] = useState<CatalogReportItem | null>(null);
+
+  // Filtered Categories list (excluding Dashboard and All Reports)
+  const validCategories = useMemo(() => {
+    return categories.filter((c) => {
+      const code = (c.catCode || "").trim().toLowerCase();
+      const name = (c.categoryName || "").trim().toLowerCase();
+      return (
+        code !== "dashboard" &&
+        name !== "dashboard" &&
+        name !== "main dashboard" &&
+        code !== "all reports" &&
+        name !== "all reports" &&
+        code !== "all" &&
+        name !== "all"
+      );
+    });
+  }, [categories]);
+
+  // Compute category card list with an "All Reports" view-all filter card at the front
+  const categoryCardsList = useMemo(() => {
+    return [
+      {
+        catCode: "ALL",
+        categoryName: "All Reports",
+        totalReports: reports.length,
+      },
+      ...validCategories,
+    ];
+  }, [validCategories, reports.length]);
+
+  // Search logic: search across all reports by Report Name or Category Name (case-insensitive)
+  const filteredReports = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+
+    return reports.filter((item) => {
+      const matchesReportName = (item.reportName || "").toLowerCase().includes(term);
+      const matchesCategoryName = (item.categoryName || "").toLowerCase().includes(term);
+      const matchesSearch = matchesReportName || matchesCategoryName;
+
+      // If user is searching, search across ALL reports in system
+      if (term) {
+        return matchesSearch;
+      }
+
+      const matchesCategory =
+        selectedCatCode === "ALL" ||
+        item.catCode.toLowerCase() === selectedCatCode.toLowerCase();
+
+      return matchesCategory;
+    });
+  }, [reports, selectedCatCode, searchTerm]);
+
+  // Handle category card selection
+  const handleSelectCategory = (catCode: string) => {
+    setSelectedCatCode(catCode);
+    setSelectedReport(null);
+  };
+
+  // Active selected report for details panel
+  const activeReport =
+    selectedReport && filteredReports.some((r) => r.repIdNo === selectedReport.repIdNo && r.repId === selectedReport.repId)
+      ? selectedReport
+      : filteredReports.length > 0
+      ? filteredReports[0]
+      : null;
+
+  // Active category display title
+  const activeCategoryTitle = useMemo(() => {
+    if (searchTerm.trim()) return `Search Results (${filteredReports.length})`;
+    if (selectedCatCode === "ALL") return "All System Reports";
+    const found = validCategories.find(
+      (c) => c.catCode.toLowerCase() === selectedCatCode.toLowerCase()
+    );
+    return found ? found.categoryName : selectedCatCode;
+  }, [selectedCatCode, validCategories, searchTerm, filteredReports.length]);
+
+  return (
+    <div className="min-h-screen bg-gray-50/50 p-4 sm:p-6 lg:p-8 space-y-6">
+      {/* Top Header Section */}
+      <div className="bg-white rounded-2xl p-6 border border-gray-200/80 shadow-xs">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2.5">
+              <div className="p-2.5 bg-[#800000]/10 text-[#800000] rounded-xl">
+                <Library className="w-6 h-6" />
+              </div>
+              <h1 className="text-2xl sm:text-3xl font-extrabold text-gray-900 tracking-tight">
+                Report Catalog
+              </h1>
+            </div>
+            <p className="text-sm text-gray-500 max-w-2xl pt-1">
+              Browse all reports available in the system. Some reports may require administrator permission.
+            </p>
+          </div>
+
+          {/* Real Database Counts */}
+          <div className="flex items-center gap-2.5 flex-wrap">
+            <div className="bg-gray-100 px-3.5 py-1.5 rounded-xl border border-gray-200 text-xs font-semibold text-gray-700">
+              Total Categories:{" "}
+              <span className="text-[#800000] font-bold">
+                {validCategories.length}
+              </span>
+            </div>
+            <div className="bg-gray-100 px-3.5 py-1.5 rounded-xl border border-gray-200 text-xs font-semibold text-gray-700">
+              Total Reports:{" "}
+              <span className="text-[#800000] font-bold">
+                {reports.length}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Loading & Error States */}
+      {loading ? (
+        <div className="flex flex-col items-center justify-center py-16 bg-white rounded-2xl border border-gray-200/80 shadow-xs">
+          <Loader2 className="w-8 h-8 text-[#800000] animate-spin mb-3" />
+          <p className="text-sm text-gray-600 font-medium">
+            Loading report catalog from database...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-2xl p-6 text-center text-red-700 text-sm">
+          {error}
+        </div>
+      ) : (
+        <>
+          {/* Category Cards Section */}
+          <div className="space-y-3">
+            <h2 className="text-xs font-bold text-gray-500 uppercase tracking-wider">
+              Report Categories ({validCategories.length})
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3.5">
+              {categoryCardsList.map((cat) => (
+                <CategoryCard
+                  key={cat.catCode}
+                  catCode={cat.catCode}
+                  categoryName={cat.categoryName}
+                  count={cat.totalReports}
+                  isSelected={selectedCatCode === cat.catCode}
+                  onSelect={handleSelectCategory}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Search Bar Section (Positioned Directly Below Category Cards & Above Report List) */}
+          <div className="bg-white rounded-2xl p-4 border border-gray-200/80 shadow-xs">
+            <SearchBar
+              searchTerm={searchTerm}
+              onSearchChange={setSearchTerm}
+              totalResults={filteredReports.length}
+            />
+          </div>
+
+          {/* Report List & Details Master-Detail Layout */}
+          {filteredReports.length > 0 ? (
+            <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
+              {/* Left Column: Report List (5 cols) */}
+              <div className="lg:col-span-5 h-full">
+                <ReportList
+                  reports={filteredReports}
+                  selectedReportId={
+                    activeReport ? activeReport.repIdNo || activeReport.repId : null
+                  }
+                  onSelectReport={setSelectedReport}
+                  categoryTitle={activeCategoryTitle}
+                />
+              </div>
+
+              {/* Right Column: Report Details (7 cols) */}
+              <div className="lg:col-span-7 h-full">
+                {activeReport && <ReportDetails report={activeReport} />}
+              </div>
+            </div>
+          ) : (
+            /* Empty State Illustration */
+            <div className="bg-white rounded-2xl p-12 border border-gray-200/80 shadow-xs text-center space-y-4 max-w-lg mx-auto my-8">
+              <div className="w-16 h-16 bg-red-50 text-[#800000] rounded-2xl flex items-center justify-center mx-auto shadow-inner">
+                <FolderSearch className="w-8 h-8" />
+              </div>
+              <div className="space-y-1">
+                <h3 className="text-lg font-bold text-gray-900">
+                  {searchTerm.trim()
+                    ? "No reports found matching your search."
+                    : "No reports found."}
+                </h3>
+                <p className="text-xs text-gray-500">
+                  {searchTerm.trim()
+                    ? `No reports matched "${searchTerm}". Try searching by report name or category.`
+                    : "There are no reports available in this category."}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchTerm("");
+                  setSelectedCatCode("ALL");
+                }}
+                className="px-4 py-2 bg-[#800000] hover:bg-[#660000] text-white text-xs font-semibold rounded-lg shadow-xs transition-colors cursor-pointer"
+              >
+                Clear Search & Filters
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ReportCatalog;

--- a/src/routes/ReportRoutes.tsx
+++ b/src/routes/ReportRoutes.tsx
@@ -27,9 +27,26 @@ import AdminHome from "../pages/AdminHome";
 import CcApplicationProgress from "../mainTopics/SolarJobs/CcApplicationProgress";
 import SolarPendingJobsReport from "../mainTopics/SolarJobs/SolarPendingJobsReport";
 import FIFODetails from "../pages/FIFODetails";
+import ReportCatalog from "../pages/ReportCatalog";
 
 const ReportRoutes = () => (
 	<>
+		<Route
+			path="/report/all-reports"
+			element={
+				<Layout>
+					<ReportCatalog />
+				</Layout>
+			}
+		/>
+		<Route
+			path="/report/catalog"
+			element={
+				<Layout>
+					<ReportCatalog />
+				</Layout>
+			}
+		/>
 		<Route
 			path="/report/general"
 			element={

--- a/src/utils/reportComponentRegistry.ts
+++ b/src/utils/reportComponentRegistry.ts
@@ -1,5 +1,8 @@
 import type { ComponentType } from "react";
 
+//Report Catalog
+import ReportCatalog from "../pages/ReportCatalog";
+
 // PIV reports
 import ProvincePIV from "../mainTopics/PIV/ProvincePIV";
 import ProvincePIVProvincial from "../mainTopics/PIV/ProvincePIVProvincial";
@@ -477,6 +480,13 @@ export const reportComponentRegistry: ReportComponentRegistry = {
 	"region trial balance": ReagionTrial,
 	"area wise trial balance": AreaTrialBalance,
 
+	// Catalog reports
+	"all reports": ReportCatalog,
+	"all-reports": ReportCatalog,
+	"report catalog": ReportCatalog,
+	"reportcatalog": ReportCatalog,
+	"catalog": ReportCatalog,
+	
 	// Work In Progress reports
 	"cost center wise work in progress with age analysis": AgeAnalysisCostCenter,
 	"cost center wise work in progress completed projects": CompletedCostCenterWise,


### PR DESCRIPTION
Implement a comprehensive report catalog system with:

- New ReportCatalog page for browsing reports by category
- Catalog UI components: CategoryCard, ReportList, ReportListItem, ReportDetails, SamplePreview, SearchBar
- useReportCatalog hook to fetch catalog data from API with role-based access control
- Category and report filtering with real-time search
- Sample output preview with zoom and lightbox modal
- Router integration with /report/all-reports and /report/catalog paths
- Component registry integration for report mapping
- Updated UserContext with RoleId and Role fields for access control
- Vite config updates for API proxy