### PR TITLE
Nethma new

### DIFF
--- a/src/components/mainTopics/Dashboard/DashboardHeader.tsx
+++ b/src/components/mainTopics/Dashboard/DashboardHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useUser } from "../../../contexts/UserContext";
 
 interface DashboardHeaderProps {
   title: string;
@@ -14,6 +15,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   const [internalDivision, setInternalDivision] = useState("all");
   const selectedDivision = externalDivision !== undefined ? externalDivision : internalDivision;
   const setDivision = onDivisionChange || setInternalDivision;
+  const { user } = useUser();
 
   const divisions = [
     { id: "all", label: "All Divisions" },
@@ -23,6 +25,18 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
     { id: "d4", label: "D4" },
   ];
 
+  const filteredDivisions = divisions.filter((division) => {
+    if (user?.Level === 80) return true;
+    if (user?.RegionCode) {
+      const match = /^R(\d+)$/i.exec(user.RegionCode.trim());
+      if (match) {
+        const allowedId = `d${match[1]}`.toLowerCase();
+        return division.id === allowedId;
+      }
+    }
+    return true;
+  });
+
   return (
     <div className="bg-white border-b border-gray-200 sticky top-0 z-10 transition-all duration-1000 opacity-100">
       <div className="max-w-7xl mx-auto px-4 py-4">
@@ -30,7 +44,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
           <div className="ml-auto flex items-center justify-end">
             <div className="flex items-center gap-2 bg-gray-100 rounded-lg p-1">
-              {divisions.map((division) => {
+              {filteredDivisions.map((division) => {
                 const isSelected = selectedDivision === division.id;
 
                 return (

--- a/src/components/mainTopics/Dashboard/DashboardSelector.tsx
+++ b/src/components/mainTopics/Dashboard/DashboardSelector.tsx
@@ -54,19 +54,7 @@ const DashboardSelector: React.FC<DashboardSelectorProps> = ({
 
   // Dynamically map assigned dashboards from Admin Panel ONLY
   const seenKeys = new Set<string>();
-
-  let list = subtopics;
-  if (user?.Level && user.Level >= 70) {
-    const hasDefault = subtopics.some((s) => getDashboardKey(s.name) === "default");
-    if (!hasDefault) {
-      list = [
-        { id: 9999, name: "Main Dashboard", repIdNo: "default" },
-        ...subtopics,
-      ];
-    }
-  }
-
-  const dashboards = list
+  const dashboards = subtopics
     .map((subtopic) => {
       const key = getDashboardKey(subtopic.name);
       return {

--- a/src/components/mainTopics/Dashboard/DashboardSelector.tsx
+++ b/src/components/mainTopics/Dashboard/DashboardSelector.tsx
@@ -54,7 +54,19 @@ const DashboardSelector: React.FC<DashboardSelectorProps> = ({
 
   // Dynamically map assigned dashboards from Admin Panel ONLY
   const seenKeys = new Set<string>();
-  const dashboards = subtopics
+
+  let list = subtopics;
+  if (user?.Level && user.Level >= 70) {
+    const hasDefault = subtopics.some((s) => getDashboardKey(s.name) === "default");
+    if (!hasDefault) {
+      list = [
+        { id: 9999, name: "Main Dashboard", repIdNo: "default" },
+        ...subtopics,
+      ];
+    }
+  }
+
+  const dashboards = list
     .map((subtopic) => {
       const key = getDashboardKey(subtopic.name);
       return {
@@ -64,7 +76,7 @@ const DashboardSelector: React.FC<DashboardSelectorProps> = ({
       };
     })
     .filter((item) => {
-      if (item.id === "default" && user?.Level !== 80) return false;
+      if (item.id === "default" && (!user?.Level || user.Level < 70)) return false;
       if (seenKeys.has(item.id)) return false;
       seenKeys.add(item.id);
       return true;

--- a/src/components/mainTopics/Dashboard/DashboardSelector.tsx
+++ b/src/components/mainTopics/Dashboard/DashboardSelector.tsx
@@ -4,6 +4,7 @@ import {
   Briefcase, Sun, CreditCard, Target, Package
 } from "lucide-react";
 import { useRoleBasedSubtopics } from "../../../hooks/useRoleBasedSubtopics";
+import { useUser } from "../../../contexts/UserContext";
 
 interface DashboardSelectorProps {
   activeDashboard: string;
@@ -40,6 +41,7 @@ const DashboardSelector: React.FC<DashboardSelectorProps> = ({
   onSelectDashboard,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const { user } = useUser();
 
   const { subtopics, loading } = useRoleBasedSubtopics([
     "Dashboard",
@@ -62,6 +64,7 @@ const DashboardSelector: React.FC<DashboardSelectorProps> = ({
       };
     })
     .filter((item) => {
+      if (item.id === "default" && user?.Level !== 80) return false;
       if (seenKeys.has(item.id)) return false;
       seenKeys.add(item.id);
       return true;

--- a/src/mainTopics/Dashboard/DefaultDashboardPage.tsx
+++ b/src/mainTopics/Dashboard/DefaultDashboardPage.tsx
@@ -11,6 +11,7 @@ import {
   Eye,
   EyeOff,
   X,
+  ShieldAlert,
 } from "lucide-react";
 import {
   ResponsiveContainer,
@@ -404,6 +405,28 @@ const DefaultDashboardPage: React.FC = () => {
   const { user } = useUser();
   const navigate = useNavigate();
   const activeDashboard = "default";
+
+  if (user?.Level !== 80) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center p-8">
+        <div className="w-full max-w-md rounded-3xl border border-stone-200 bg-white p-8 text-center shadow-lg shadow-stone-200/50">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-50 text-amber-600 border border-amber-100">
+            <ShieldAlert className="h-8 w-8" />
+          </div>
+          <h2 className="text-xl font-bold text-stone-900">Access Denied</h2>
+          <p className="mt-2 text-sm text-stone-600">
+            The default dashboard is only accessible to the Chairman.
+          </p>
+          <button
+            onClick={() => navigate("/home")}
+            className="mt-6 px-5 py-2.5 rounded-xl bg-[#7A0000] text-white text-xs font-semibold hover:bg-[#600000] transition-colors shadow-sm"
+          >
+            Back to Home
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   const [selectedDivision, setSelectedDivision] = useState("all");
   const toRegion = (division: string) => {

--- a/src/mainTopics/Dashboard/DefaultDashboardPage.tsx
+++ b/src/mainTopics/Dashboard/DefaultDashboardPage.tsx
@@ -406,7 +406,7 @@ const DefaultDashboardPage: React.FC = () => {
   const navigate = useNavigate();
   const activeDashboard = "default";
 
-  if (user?.Level !== 80) {
+  if (!user?.Level || user.Level < 70) {
     return (
       <div className="flex min-h-[70vh] items-center justify-center p-8">
         <div className="w-full max-w-md rounded-3xl border border-stone-200 bg-white p-8 text-center shadow-lg shadow-stone-200/50">
@@ -415,7 +415,7 @@ const DefaultDashboardPage: React.FC = () => {
           </div>
           <h2 className="text-xl font-bold text-stone-900">Access Denied</h2>
           <p className="mt-2 text-sm text-stone-600">
-            The default dashboard is only accessible to the Chairman.
+            You do not have permission to view the default dashboard.
           </p>
           <button
             onClick={() => navigate("/home")}
@@ -428,7 +428,15 @@ const DefaultDashboardPage: React.FC = () => {
     );
   }
 
-  const [selectedDivision, setSelectedDivision] = useState("all");
+  const [selectedDivision, setSelectedDivision] = useState(() => {
+    if (user?.Level !== 80 && user?.RegionCode) {
+      const match = /^R(\d+)$/i.exec(user.RegionCode.trim());
+      if (match) {
+        return `d${match[1]}`.toLowerCase();
+      }
+    }
+    return "all";
+  });
   const toRegion = (division: string) => {
     const match = /^d(\d+)$/i.exec(division || "");
     return match ? `R${match[1]}` : null;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useRoleBasedSubtopics } from "../hooks/useRoleBasedSubtopics";
 import { ShieldAlert, RefreshCw } from "lucide-react";
+import { useUser } from "../contexts/UserContext";
 
 import DefaultDashboardPage from "../mainTopics/Dashboard/DefaultDashboardPage";
 import AnalyticsDashboardPage from "../mainTopics/Dashboard/AnalyticsDashboardPage";
@@ -40,6 +41,7 @@ const getDashboardKey = (name: string): string => {
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
   const { dashboardId } = useParams<{ dashboardId?: string }>();
+  const { user } = useUser();
 
   const { subtopics, loading } = useRoleBasedSubtopics([
     "Dashboard",
@@ -50,17 +52,27 @@ const Dashboard: React.FC = () => {
     "Dashboards",
   ]);
 
-  useEffect(() => {
-    if (loading || subtopics.length === 0) return;
+  const filteredSubtopics = useMemo(() => {
+    return subtopics.filter((subtopic) => {
+      const key = getDashboardKey(subtopic.name);
+      if (key === "default" && user?.Level !== 80) {
+        return false;
+      }
+      return true;
+    });
+  }, [subtopics, user?.Level]);
 
-    const allowedKeys = subtopics.map((s) => getDashboardKey(s.name));
+  useEffect(() => {
+    if (loading || filteredSubtopics.length === 0) return;
+
+    const allowedKeys = filteredSubtopics.map((s) => getDashboardKey(s.name));
     const firstAllowedKey = allowedKeys[0];
 
     // If no dashboardId in URL, OR if the URL dashboardId is no longer allowed for this role:
     if (!dashboardId || !allowedKeys.includes(dashboardId)) {
       navigate(`/dashboard/${firstAllowedKey}`, { replace: true });
     }
-  }, [dashboardId, subtopics, loading, navigate]);
+  }, [dashboardId, filteredSubtopics, loading, navigate]);
 
   // Render smooth spinner while checking permissions
   if (loading) {
@@ -75,7 +87,7 @@ const Dashboard: React.FC = () => {
   }
 
   // Render modern empty state if no dashboards assigned
-  if (subtopics.length === 0) {
+  if (filteredSubtopics.length === 0) {
     return (
       <div className="flex min-h-[70vh] items-center justify-center p-8">
         <div className="w-full max-w-md rounded-3xl border border-stone-200 bg-white p-8 text-center shadow-lg shadow-stone-200/50">
@@ -96,7 +108,7 @@ const Dashboard: React.FC = () => {
     );
   }
 
-  const allowedKeys = subtopics.map((s) => getDashboardKey(s.name));
+  const allowedKeys = filteredSubtopics.map((s) => getDashboardKey(s.name));
   const activeDashboard = (dashboardId && allowedKeys.includes(dashboardId)) 
     ? dashboardId 
     : allowedKeys[0];

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -53,18 +53,7 @@ const Dashboard: React.FC = () => {
   ]);
 
   const filteredSubtopics = useMemo(() => {
-    let list = subtopics;
-    if (user?.Level && user.Level >= 70) {
-      const hasDefault = subtopics.some((s) => getDashboardKey(s.name) === "default");
-      if (!hasDefault) {
-        list = [
-          { id: 9999, name: "Main Dashboard", repIdNo: "default" },
-          ...subtopics,
-        ];
-      }
-    }
-
-    return list.filter((subtopic) => {
+    return subtopics.filter((subtopic) => {
       const key = getDashboardKey(subtopic.name);
       if (key === "default" && (!user?.Level || user.Level < 70)) {
         return false;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -53,9 +53,20 @@ const Dashboard: React.FC = () => {
   ]);
 
   const filteredSubtopics = useMemo(() => {
-    return subtopics.filter((subtopic) => {
+    let list = subtopics;
+    if (user?.Level && user.Level >= 70) {
+      const hasDefault = subtopics.some((s) => getDashboardKey(s.name) === "default");
+      if (!hasDefault) {
+        list = [
+          { id: 9999, name: "Main Dashboard", repIdNo: "default" },
+          ...subtopics,
+        ];
+      }
+    }
+
+    return list.filter((subtopic) => {
       const key = getDashboardKey(subtopic.name);
-      if (key === "default" && user?.Level !== 80) {
+      if (key === "default" && (!user?.Level || user.Level < 70)) {
         return false;
       }
       return true;


### PR DESCRIPTION
implement dashboard role-based access control to chairman level
implement dashboard role-based access control and division locks


- Restricts the default dashboard to users with Level >= 70 (Chairman and Region DGMs).
- Locks Region users (Level 70) to their respective division view (e.g. D2 for Region R2) and hides other division options.
- Blocks Level < 70 users from accessing the default dashboard entirely.