### PR TITLE
Add SMC Job Progress report and page

### DIFF
--- a/src/mainTopics/SMC-ManagementInfo/SMCJobProgressReport.tsx
+++ b/src/mainTopics/SMC-ManagementInfo/SMCJobProgressReport.tsx
@@ -1,0 +1,773 @@
+// SmcJobProgressReport.tsx
+import React, {useEffect, useState} from "react";
+import {Download, Printer, X, RotateCcw, Eye, Search} from "lucide-react";
+import {toast} from "react-toastify";
+import {useUser} from "../../contexts/UserContext";
+
+interface Department {
+	DeptId: string;
+	DeptName: string;
+}
+
+interface SmcJobProgressItem {
+	ApplicationNo: string | null;
+	SubmitDate: string | null;
+	ApprovedDate: string | null;
+	Piv2ConfirmedDate: string | null;
+	DNoticeDays: number | null;
+	AllocatedDate: string | null;
+	FinishedDate: string | null;
+	ProjectNo: string | null;
+	EstimateDt: string | null;
+	PrjAssDt: string | null;
+	EngizedDate: string | null;
+	AccNo: string | null;
+	AccDate: string | null;
+	T1: number | null;
+	T2Smc: number | null;
+	T3: number | null;
+	CctName: string | null;
+}
+
+/* ────── Constants ────── */
+const MAX_RECORDS = 5000;
+const FETCH_TIMEOUT_MS = 120000;
+const PAGE_SIZE = 9;
+
+/* ────── Formatting helpers ────── */
+const formatDate = (dateStr: string | null): string => {
+	if (!dateStr) return "";
+	const d = new Date(dateStr);
+	if (isNaN(d.getTime())) return "";
+	const year = d.getFullYear();
+	const month = String(d.getMonth() + 1).padStart(2, "0");
+	const day = String(d.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+};
+
+const formatDays = (num: number | null | undefined): string => {
+	if (num === null || num === undefined || isNaN(Number(num))) return "";
+	return Math.round(Number(num)).toString();
+};
+
+const csvEscape = (val: string | number | null | undefined): string => {
+	if (val == null) return "";
+	const str = String(val);
+	if (/[,\n"]/.test(str)) return `"${str.replace(/"/g, '""')}"`;
+	return str;
+};
+
+const today = new Date();
+const currentYear = today.getFullYear();
+const currentMonth = String(today.getMonth() + 1).padStart(2, "0");
+const currentDay = String(today.getDate()).padStart(2, "0");
+const maxDate = `${currentYear}-${currentMonth}-${currentDay}`;
+
+const minYear = currentYear - 20;
+const minDate = `${minYear}-${currentMonth}-${currentDay}`;
+
+/* ────── MAIN COMPONENT ────── */
+const SmcJobProgressReport: React.FC = () => {
+	const {user} = useUser();
+	const epfNo = user?.Userno || "";
+
+	/* ── Cost Center list state ── */
+	const [departments, setDepartments] = useState<Department[]>([]);
+	const [filtered, setFiltered] = useState<Department[]>([]);
+	const [searchId, setSearchId] = useState("");
+	const [searchName, setSearchName] = useState("");
+	const [page, setPage] = useState(1);
+	const [deptLoading, setDeptLoading] = useState(true);
+	const [deptError, setDeptError] = useState<string | null>(null);
+
+	/* ── Report state ── */
+	const [fromDate, setFromDate] = useState("");
+	const [toDate, setToDate] = useState("");
+	const [selectedDept, setSelectedDept] = useState<Department | null>(null);
+	const [reportData, setReportData] = useState<SmcJobProgressItem[]>([]);
+	const [reportLoading, setReportLoading] = useState(false);
+	const [showReport, setShowReport] = useState(false);
+
+	const maroon = "text-[#7A0000]";
+	const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
+
+	/* ────── Fetch Departments ────── */
+	useEffect(() => {
+		const fetchDepartments = async () => {
+			if (!epfNo) {
+				setDeptError("No EPF number available.");
+				toast.error("Login required.");
+				setDeptLoading(false);
+				return;
+			}
+
+			setDeptLoading(true);
+			try {
+				const res = await fetch(
+					`/misapi/api/incomeexpenditure/departments/${epfNo}`
+				);
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				const json = await res.json();
+				const raw = Array.isArray(json)
+					? json
+					: json.data || json.result || json.departments || [];
+				const deps: Department[] = raw.map((d: any) => ({
+					DeptId: String(d.DeptId || d.deptId || ""),
+					DeptName: String(d.DeptName || d.deptName || "").trim(),
+				}));
+				setDepartments(deps);
+				setFiltered(deps);
+			} catch (e: any) {
+				setDeptError(e.message);
+				toast.error("Failed to load cost centers.");
+			} finally {
+				setDeptLoading(false);
+			}
+		};
+		fetchDepartments();
+	}, [epfNo]);
+
+	/* ────── Filter Departments ────── */
+	useEffect(() => {
+		const f = departments.filter(
+			(d) =>
+				(!searchId ||
+					d.DeptId.toLowerCase().includes(searchId.toLowerCase())) &&
+				(!searchName ||
+					d.DeptName.toLowerCase().includes(searchName.toLowerCase()))
+		);
+		setFiltered(f);
+		setPage(1);
+	}, [searchId, searchName, departments]);
+
+	/* ────── Input validation ────── */
+	const validateInputs = (): boolean => {
+		if (!fromDate) {
+			toast.error("Please select 'From Date'");
+			return false;
+		}
+		if (!toDate) {
+			toast.error("Please select 'To Date'");
+			return false;
+		}
+		if (new Date(toDate) < new Date(fromDate)) {
+			toast.error("'To Date' cannot be earlier than 'From Date'");
+			return false;
+		}
+		return true;
+	};
+
+	/* ────── Fetch report for a selected Cost Center ────── */
+	const fetchReport = async (dept: Department) => {
+		if (!validateInputs()) return;
+
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+		setSelectedDept(dept);
+		setReportLoading(true);
+		setReportData([]);
+		setShowReport(true);
+
+		try {
+			const costCtrParam = encodeURIComponent(dept.DeptId);
+			const url = `/misapi/api/smcjobprogress/report/${fromDate}/${toDate}/${costCtrParam}`;
+
+			const res = await fetch(url, {
+				credentials: "include",
+				signal: controller.signal,
+			});
+			clearTimeout(timeoutId);
+
+			if (!res.ok) {
+				const txt = await res.text();
+				throw new Error(`HTTP ${res.status}: ${txt}`);
+			}
+
+			const json = await res.json();
+			if (!json.success)
+				throw new Error(json.message || "Failed to load data");
+
+			const items: SmcJobProgressItem[] = json.data || [];
+			if (items.length > MAX_RECORDS)
+				throw new Error(
+					`Too many records (${items.length}). Please refine your search.`
+				);
+
+			if (items.length === 0) {
+				toast.warn("No records found for the selected criteria.");
+				setShowReport(false);
+				setSelectedDept(null);
+				return;
+			}
+
+			setReportData(items);
+			toast.success(`${items.length} records loaded successfully.`);
+		} catch (e: any) {
+			if (e.name === "AbortError") {
+				toast.error("Request timed out.");
+			} else {
+				const msg = e.message.includes("Failed to fetch")
+					? "Server unreachable. Please check your connection."
+					: e.message;
+				toast.error(msg);
+			}
+			setReportData([]);
+			setShowReport(false);
+			setSelectedDept(null);
+		} finally {
+			setReportLoading(false);
+		}
+	};
+
+	const clearFilters = () => {
+		setSearchId("");
+		setSearchName("");
+	};
+
+	const clearAll = () => {
+		setFromDate("");
+		setToDate("");
+		setSearchId("");
+		setSearchName("");
+		setShowReport(false);
+		setReportData([]);
+		setSelectedDept(null);
+		toast.info("Filters cleared.");
+	};
+
+	const closeReport = () => {
+		setShowReport(false);
+		setReportData([]);
+		setSelectedDept(null);
+		setReportLoading(false);
+	};
+
+	/* ────── Sorted per SQL: application_no ────── */
+	const sortedData = [...reportData].sort((a, b) =>
+		(a.ApplicationNo || "").localeCompare(b.ApplicationNo || "")
+	);
+
+	const cctName = reportData.find((r) => r.CctName)?.CctName || selectedDept?.DeptName || "";
+	const costCtrDisplay = selectedDept?.DeptId || "";
+
+	/* ────── CSV download ────── */
+	const downloadCSV = () => {
+		if (reportData.length === 0) return;
+
+		const titleRows = [
+			`SMC Job Progress - From ${fromDate} To ${toDate}`,
+			`Cost center: ${costCtrDisplay}/ ${cctName}`,
+			"",
+		];
+
+		const headers = [
+			"Application No",
+			"Submit Date",
+			"Estimate Date",
+			"PIV2 Confirm",
+			"D-Notice Days",
+			"Allocate Date",
+			"Finished Date",
+			"Project No",
+			"Proj. Ass. Date",
+			"Engized Date",
+			"Account No",
+			"Account Created Date",
+			"T1",
+			"T2",
+			"T3",
+		];
+		const rows: string[] = [headers.join(",")];
+
+		sortedData.forEach((it) => {
+			rows.push(
+				[
+					csvEscape(it.ApplicationNo),
+					csvEscape(formatDate(it.SubmitDate)),
+					csvEscape(formatDate(it.EstimateDt)),
+					csvEscape(formatDate(it.Piv2ConfirmedDate)),
+					csvEscape(formatDays(it.DNoticeDays)),
+					csvEscape(formatDate(it.AllocatedDate)),
+					csvEscape(formatDate(it.FinishedDate)),
+					csvEscape(it.ProjectNo),
+					csvEscape(formatDate(it.PrjAssDt)),
+					csvEscape(formatDate(it.EngizedDate)),
+					csvEscape(it.AccNo),
+					csvEscape(formatDate(it.AccDate)),
+					csvEscape(formatDays(it.T1)),
+					csvEscape(formatDays(it.T2Smc)),
+					csvEscape(formatDays(it.T3)),
+				].join(",")
+			);
+		});
+
+		const csv = [...titleRows, ...rows].join("\n");
+		const blob = new Blob([csv], {type: "text/csv;charset=utf-8;"});
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `SmcJobProgress_${fromDate}_${toDate}.csv`;
+		a.click();
+		URL.revokeObjectURL(url);
+	};
+
+	/* ────── PDF print ────── */
+	const printPDF = () => {
+		if (reportData.length === 0) return;
+
+		let rows = "";
+		sortedData.forEach((it, i) => {
+			rows += `
+          <tr class="${i % 2 ? "bg-white" : "bg-gray-50"}">
+            <td class="px-2 py-2 border-l border-r border-gray-300 text-left text-xs font-mono">${
+					it.ApplicationNo || ""
+				}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.SubmitDate
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.EstimateDt
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.Piv2ConfirmedDate
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-right text-xs">${formatDays(
+					it.DNoticeDays
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.AllocatedDate
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.FinishedDate
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-left text-xs font-mono">${
+					it.ProjectNo || ""
+				}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.PrjAssDt
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.EngizedDate
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-left text-xs">${
+					it.AccNo || ""
+				}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-center text-xs">${formatDate(
+					it.AccDate
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-right text-xs">${formatDays(
+					it.T1
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-right text-xs">${formatDays(
+					it.T2Smc
+				)}</td>
+            <td class="px-2 py-2 border-r border-gray-300 text-right text-xs">${formatDays(
+					it.T3
+				)}</td>
+          </tr>`;
+		});
+
+		const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    @media print {
+      @page { margin: 8mm 5mm 10mm 5mm; size: landscape; }
+      body { margin:0; font-family:Arial,Helvetica,sans-serif; }
+      .title { margin: 10px 8px 20px; text-align:center; font-weight:bold; color:#7A0000; font-size:13px; }
+      .info { margin:6px 8px; font-size:9px; }
+      table { border-collapse:collapse; width:100%; font-size:7.5px; }
+      th, td { border:1px solid #d1d5db; padding:4px 5px; word-wrap:break-word; }
+      th { background:linear-gradient(to right,#7A0000,#A52A2A); color:white; text-align:center; font-weight:bold; }
+      .font-mono { font-family:monospace; }
+      @page {
+        @bottom-left  { content:"Printed on: ${new Date().toLocaleString(
+				"en-US",
+				{timeZone: "Asia/Colombo"}
+			)}"; font-size:7px; color:gray; }
+        @bottom-right { content:"Page " counter(page) " of " counter(pages); font-size:7px; color:gray; }
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="title">SMC Job Progress - From ${fromDate} To ${toDate}</div>
+  <div class="info"><strong>Cost center:</strong> ${costCtrDisplay}/ ${cctName}</div>
+  <table style="width:100%; border-collapse:collapse; font-size:7.5px; border:1px solid #d1d5db;">
+    <thead>
+      <tr style="background:linear-gradient(to right,#7A0000,#A52A2A); color:white;">
+        <th style="padding:4px 5px; width:8%;">Application No</th>
+        <th style="padding:4px 5px; width:6%;">Submit Date</th>
+        <th style="padding:4px 5px; width:6%;">Estimate Date</th>
+        <th style="padding:4px 5px; width:6%;">PIV2 Confirm</th>
+        <th style="padding:4px 5px; width:6%; text-align:right;">D-Notice Days</th>
+        <th style="padding:4px 5px; width:6%;">Allocate Date</th>
+        <th style="padding:4px 5px; width:6%;">Finished Date</th>
+        <th style="padding:4px 5px; width:8%;">Project No</th>
+        <th style="padding:4px 5px; width:6%;">Proj. Ass. Date</th>
+        <th style="padding:4px 5px; width:6%;">Engized Date</th>
+        <th style="padding:4px 5px; width:8%;">Account No</th>
+        <th style="padding:4px 5px; width:7%;">Account Created Date</th>
+        <th style="padding:4px 5px; width:4%; text-align:right;">T1</th>
+        <th style="padding:4px 5px; width:4%; text-align:right;">T2</th>
+        <th style="padding:4px 5px; width:4%; text-align:right;">T3</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>
+</body>
+</html>`;
+
+		const win = window.open("", "_blank");
+		if (!win) {
+			toast.error("Popup blocked. Please allow popups.");
+			return;
+		}
+		win.document.write(html);
+		win.document.close();
+		win.onload = () => win.print();
+		win.onafterprint = () => win.close();
+	};
+
+	const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+	/* ────── RENDER ────── */
+	return (
+		<div className="max-w-7xl mx-auto p-6 bg-white rounded-xl shadow border border-gray-200 text-sm font-sans">
+			<div className="flex justify-between items-center mb-4">
+				<h2 className={`text-xl font-bold ${maroon}`}>
+					SMC Job Progress
+				</h2>
+			</div>
+
+			<div className="bg-gray-50 p-4 rounded-lg mb-4 border border-gray-200">
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-end">
+					{/* From Date */}
+					<div className="flex items-center gap-2">
+						<label
+							className={`text-xs font-bold ${maroon} whitespace-nowrap`}
+						>
+							From Date:
+						</label>
+						<input
+							type="date"
+							value={fromDate}
+							onChange={(e) => setFromDate(e.target.value)}
+							min={minDate}
+							max={maxDate}
+							className="pl-3 pr-3 py-1.5 w-full rounded-md border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-[#7A0000] transition text-sm"
+						/>
+					</div>
+
+					{/* To Date */}
+					<div className="flex items-center gap-2">
+						<label
+							className={`text-xs font-bold ${maroon} whitespace-nowrap`}
+						>
+							To Date:
+						</label>
+						<input
+							type="date"
+							value={toDate}
+							onChange={(e) => setToDate(e.target.value)}
+							min={minDate}
+							max={maxDate}
+							className="pl-3 pr-3 py-1.5 w-full rounded-md border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-[#7A0000] transition text-sm"
+						/>
+					</div>
+				</div>
+
+				<div className="flex justify-end mt-4">
+					<button
+						onClick={clearAll}
+						className="flex items-center gap-1 px-3 py-1.5 border border-gray-300 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
+					>
+						<RotateCcw className="w-3 h-3" /> Clear All
+					</button>
+				</div>
+			</div>
+
+			{/* ────── Cost Center List ────── */}
+			<div className="flex flex-wrap gap-2 mb-4">
+				<div className="relative">
+					<Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+					<input
+						type="text"
+						value={searchId}
+						placeholder="Search by ID"
+						onChange={(e) => setSearchId(e.target.value)}
+						className="pl-10 pr-3 py-1.5 w-40 rounded border border-gray-300 focus:ring-2 focus:ring-[#7A0000] text-sm"
+					/>
+				</div>
+				<div className="relative">
+					<Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+					<input
+						type="text"
+						value={searchName}
+						placeholder="Search by Name"
+						onChange={(e) => setSearchName(e.target.value)}
+						className="pl-10 pr-3 py-1.5 w-40 rounded border border-gray-300 focus:ring-2 focus:ring-[#7A0000] text-sm"
+					/>
+				</div>
+				{(searchId || searchName) && (
+					<button
+						onClick={clearFilters}
+						className="flex items-center gap-1 px-3 py-1.5 border rounded bg-gray-100 hover:bg-gray-200 text-xs"
+					>
+						<RotateCcw className="w-3 h-3" /> Clear
+					</button>
+				)}
+			</div>
+
+			{deptLoading && (
+				<div className="flex flex-col items-center justify-center py-12">
+					<div className="animate-spin rounded-full h-12 w-12 border-b-4 border-[#7A0000]"></div>
+					<p className="mt-3 text-gray-600 text-sm">
+						Loading cost centers...
+					</p>
+				</div>
+			)}
+
+			{deptError && (
+				<div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4 text-sm">
+					{deptError}
+				</div>
+			)}
+
+			{!deptLoading && !deptError && filtered.length > 0 && (
+				<>
+					<div className="overflow-x-auto rounded-lg border border-gray-200">
+						<div className="max-h-[50vh] overflow-y-auto">
+							<table className="w-full table-fixed text-left text-xs md:text-sm">
+								<thead
+									className={`${maroonGrad} text-white sticky top-0`}
+								>
+									<tr>
+										<th className="px-4 py-2 w-1/4">
+											Cost Center Code
+										</th>
+										<th className="px-4 py-2 w-1/2">
+											Cost Center Name
+										</th>
+										<th className="px-4 py-2 w-1/4 text-center">
+											Action
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{paginated.map((dept, i) => (
+										<tr
+											key={i}
+											className={i % 2 ? "bg-white" : "bg-gray-50"}
+										>
+											<td className="px-4 py-2 truncate">
+												{dept.DeptId}
+											</td>
+											<td className="px-4 py-2 truncate">
+												{dept.DeptName}
+											</td>
+											<td className="px-4 py-2 text-center">
+												<button
+													onClick={() => fetchReport(dept)}
+													disabled={!fromDate || !toDate}
+													className={`px-3 py-1 rounded text-xs font-medium hover:brightness-110 transition shadow disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1 mx-auto
+                            ${
+											selectedDept?.DeptId === dept.DeptId &&
+											reportLoading
+												? "bg-green-600 text-white"
+												: selectedDept?.DeptId === dept.DeptId
+												? "bg-green-600 text-white"
+												: `${maroonGrad} text-white`
+										}`}
+												>
+													<Eye className="w-3 h-3" />
+													{selectedDept?.DeptId === dept.DeptId &&
+													reportLoading
+														? "Viewing"
+														: selectedDept?.DeptId === dept.DeptId
+														? "Viewing"
+														: "View"}
+												</button>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+
+					<div className="flex justify-end items-center gap-3 mt-3">
+						<button
+							onClick={() => setPage((p) => Math.max(1, p - 1))}
+							disabled={page === 1}
+							className="px-3 py-1 border rounded bg-white text-gray-600 text-xs hover:bg-gray-100 disabled:opacity-40"
+						>
+							Previous
+						</button>
+						<span className="text-xs text-gray-600">
+							Page {page} of {Math.ceil(filtered.length / PAGE_SIZE)}
+						</span>
+						<button
+							onClick={() =>
+								setPage((p) =>
+									Math.min(
+										Math.ceil(filtered.length / PAGE_SIZE),
+										p + 1
+									)
+								)
+							}
+							disabled={page >= Math.ceil(filtered.length / PAGE_SIZE)}
+							className="px-3 py-1 border rounded bg-white text-gray-600 text-xs hover:bg-gray-100 disabled:opacity-40"
+						>
+							Next
+						</button>
+					</div>
+				</>
+			)}
+
+			{/* ────── REPORT MODAL ────── */}
+			{showReport && selectedDept && (
+				<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-white/90 print:static print:inset-auto print:p-0 print:bg-white">
+					<div className="relative bg-white w-[97vw] sm:w-[95vw] md:w-[92vw] lg:w-[90vw] xl:w-[88vw] max-w-[1700px] rounded-2xl shadow-2xl border border-gray-200 overflow-hidden mt-20 md:mt-32 lg:mt-40 lg:ml-64 mx-auto print:relative print:w-full print:max-w-none print:rounded-none print:shadow-none print:border-none print:overflow-visible">
+						{reportLoading && (
+							<div className="absolute inset-0 bg-white/95 z-50 flex flex-col items-center justify-center gap-4">
+								<div className="animate-spin rounded-full h-16 w-16 border-b-4 border-[#7A0000]"></div>
+								<p className="text-xl font-bold text-[#7A0000]">
+									Loading Report...
+								</p>
+								<p className="text-sm text-gray-600">
+									Fetching SMC job progress data from server
+								</p>
+							</div>
+						)}
+						{!reportLoading && reportData.length > 0 && (
+							<div className="p-2 md:p-2 max-h-[80vh] overflow-y-auto print:p-0 print:max-h-none print:overflow-visible print:mt-10 print:ml-12">
+								<div className="flex justify-end gap-3 mb-6 md:mb-8 print:hidden">
+									<button
+										onClick={downloadCSV}
+										className="flex items-center gap-1 px-3 py-1.5 border border-blue-400 text-blue-700 bg-white rounded-md text-xs font-medium shadow-sm hover:bg-blue-50"
+									>
+										<Download className="w-4 h-4" /> CSV
+									</button>
+									<button
+										onClick={printPDF}
+										className="flex items-center gap-1 px-3 py-1.5 border border-green-400 text-green-700 bg-white rounded-md text-xs font-medium shadow-sm hover:bg-green-50"
+									>
+										<Printer className="w-4 h-4" /> PDF
+									</button>
+									<button
+										onClick={closeReport}
+										className="flex items-center gap-1 px-3 py-1.5 border border-red-400 text-red-700 bg-white rounded-md text-xs font-medium shadow-sm hover:bg-red-50"
+									>
+										<X className="w-4 h-4" /> Close
+									</button>
+								</div>
+
+								<h2
+									className={`text-lg md:text-xl font-bold text-center md:mb-2 ${maroon}`}
+								>
+									SMC Job Progress - From {fromDate} To {toDate}
+								</h2>
+								<div className="text-sm mb-3 ml-5 mr-12">
+									<span className="font-bold">Cost center:</span>{" "}
+									{costCtrDisplay}/ {cctName}
+								</div>
+
+								<div className="ml-5 mt-1 mb-5 border border-gray-200 rounded-lg overflow-x-auto print:ml-12 print:mt-12 print:overflow-visible">
+									<div className="min-w-[1600px]">
+										<table className="w-full text-xs border-collapse">
+											<thead className={`${maroonGrad} text-white`}>
+												<tr>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "8%"}}>Application No</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>Submit Date</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>Estimate Date</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>PIV2 Confirm</th>
+													<th className="px-2 py-2 border border-gray-300 text-right" style={{width: "6%"}}>D-Notice Days</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>Allocate Date</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>Finished Date</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "8%"}}>Project No</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>Proj. Ass. Date</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "6%"}}>Engized Date</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "8%"}}>Account No</th>
+													<th className="px-2 py-2 border border-gray-300" style={{width: "7%"}}>Account Created Date</th>
+													<th className="px-2 py-2 border border-gray-300 text-right" style={{width: "4%"}}>T1</th>
+													<th className="px-2 py-2 border border-gray-300 text-right" style={{width: "4%"}}>T2</th>
+													<th className="px-2 py-2 border border-gray-300 text-right" style={{width: "4%"}}>T3</th>
+												</tr>
+											</thead>
+											<tbody>
+												{sortedData.map((it, i) => (
+													<tr
+														key={i}
+														className={
+															i % 2 === 0
+																? "bg-white"
+																: "bg-gray-50"
+														}
+													>
+														<td className="px-2 py-2 border-l border-r border-gray-300 font-mono">
+															{it.ApplicationNo || ""}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.SubmitDate)}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.EstimateDt)}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.Piv2ConfirmedDate)}
+														</td>
+														<td className="px-2 py-2 text-right font-mono border-r border-gray-300">
+															{formatDays(it.DNoticeDays)}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.AllocatedDate)}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.FinishedDate)}
+														</td>
+														<td className="px-2 py-2 border-r border-gray-300 font-mono">
+															{it.ProjectNo || ""}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.PrjAssDt)}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.EngizedDate)}
+														</td>
+														<td className="px-2 py-2 border-r border-gray-300">
+															{it.AccNo || ""}
+														</td>
+														<td className="px-2 py-2 text-center border-r border-gray-300">
+															{formatDate(it.AccDate)}
+														</td>
+														<td className="px-2 py-2 text-right font-mono border-r border-gray-300">
+															{formatDays(it.T1)}
+														</td>
+														<td className="px-2 py-2 text-right font-mono border-r border-gray-300">
+															{formatDays(it.T2Smc)}
+														</td>
+														<td className="px-2 py-2 text-right font-mono border-r border-gray-300">
+															{formatDays(it.T3)}
+														</td>
+													</tr>
+												))}
+											</tbody>
+										</table>
+										<p className="text-xs text-gray-500 mt-2 text-right px-2">
+											Total records: {reportData.length.toLocaleString()}
+										</p>
+									</div>
+								</div>
+							</div>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default SmcJobProgressReport;

--- a/src/pages/SMCManagementInfo.tsx
+++ b/src/pages/SMCManagementInfo.tsx
@@ -1,0 +1,43 @@
+import {useState, useEffect} from "react";
+import { useRoleBasedSubtopics } from "../hooks/useRoleBasedSubtopics";
+import SubtopicCard from "../components/shared/SubtopicCard";
+import { useReportRenderer } from "../hooks/useReportRenderer";
+
+const SMCManagementInfo = () => {
+    const { subtopics, selectedSubtopicId } = useRoleBasedSubtopics(["SMC - Management Information"]);
+    const [expandedCard, setExpandedCard] = useState<number | null>(null);
+  const renderReport = useReportRenderer();
+
+    useEffect(() => {
+        if (typeof selectedSubtopicId === "number") {
+            setExpandedCard(selectedSubtopicId);
+        }
+    }, [selectedSubtopicId]);
+
+    const toggleCard = (id: number) => {
+        setExpandedCard((prev) => (prev === id ? null : id));
+    };
+
+    return (
+        <div className="flex flex-col gap-4 pt-4 px-10">
+            {subtopics.map((subtopic) => (
+                <SubtopicCard
+                    key={subtopic.id}
+                    id={subtopic.id}
+                    title={subtopic.name}
+                    expanded={expandedCard === subtopic.id}
+                    onToggle={toggleCard}
+                >
+                    {renderReport(subtopic.name, subtopic.repIdNo ?? String(subtopic.id))}
+                </SubtopicCard>
+            ))}
+        </div>
+    );
+};
+
+export default SMCManagementInfo;
+
+
+
+
+

--- a/src/routes/ReportRoutes.tsx
+++ b/src/routes/ReportRoutes.tsx
@@ -28,6 +28,7 @@ import CcApplicationProgress from "../mainTopics/SolarJobs/CcApplicationProgress
 import SolarPendingJobsReport from "../mainTopics/SolarJobs/SolarPendingJobsReport";
 import FIFODetails from "../pages/FIFODetails";
 import ReportCatalog from "../pages/ReportCatalog";
+import SMCManagementInfo from "../pages/SMCManagementInfo";
 
 const ReportRoutes = () => (
 	<>
@@ -260,6 +261,15 @@ const ReportRoutes = () => (
 			element={
 				<Layout>
 					<SolarReligiousPurpose />
+				</Layout>
+			}
+		/>
+
+		<Route
+			path="/report/smc-management-information"
+			element={
+				<Layout>
+					<SMCManagementInfo />
 				</Layout>
 			}
 		/>

--- a/src/utils/reportComponentRegistry.ts
+++ b/src/utils/reportComponentRegistry.ts
@@ -190,6 +190,10 @@ import CollectionsDashboardPage from "../mainTopics/Dashboard/CollectionsDashboa
 import ExecutiveDashboardPage from "../mainTopics/Dashboard/ExecutiveDashboardPage";
 import InventoryDashboardPage from "../mainTopics/Dashboard/InventoryDashboardPage";
 
+//SMC - Management Information
+import SMCManagementInfo from "../pages/SMCManagementInfo";
+import SmcJobProgressReport from "../mainTopics/SMC-ManagementInfo/SMCJobProgressReport.tsx";
+
 export type ReportComponentRegistry = Record<string, ComponentType>;
 
 /**
@@ -429,6 +433,9 @@ export const reportComponentRegistry: ReportComponentRegistry = {
 	"collections & payments dashboard": CollectionsDashboardPage,
 	"executive dashboard": ExecutiveDashboardPage,
 	"inventory dashboard": InventoryDashboardPage,
+
+	//SMC - Management Information
+	"smc job progress": SmcJobProgressReport,
 };
 
 /**


### PR DESCRIPTION
Introduce SMC Job Progress feature: add SmcJobProgressReport component (src/mainTopics/SMC-ManagementInfo/SMCJobProgressReport.tsx) with department fetch, date filters, pagination, report fetch with timeout, CSV export and print-friendly PDF, input validation and UX states. Add SMCManagementInfo page (src/pages/SMCManagementInfo.tsx) which renders subtopic cards via role-based hooks. Hook up a route /report/smc-management-information in ReportRoutes and register the report component in reportComponentRegistry under "smc job progress".