### PR TITLE
feat: Add level-based access control (Chairman/Region/Province/Area) to Collections reports

### DIFF
--- a/src/mainTopics/Collections/CustomersHighestOutstanding.tsx
+++ b/src/mainTopics/Collections/CustomersHighestOutstanding.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 interface Province {
   ProvinceCode: string;
@@ -64,6 +66,9 @@ const CustomersHighestOutstanding: React.FC = () => {
   const printRef = useRef<HTMLDivElement>(null);
   const printTableRef = useRef<HTMLTableElement>(null);
 
+  const { user } = useUser();
+  const { locked } = useReportScope();
+
   const maroon = "text-[#7A0000]";
   const maroonGrad = "bg-gradient-to-r from-[#7A0000] to-[#A52A2A]";
 
@@ -73,13 +78,14 @@ const CustomersHighestOutstanding: React.FC = () => {
       setIsLoadingProvinces(true);
       setProvinceError(null);
       try {
-        const res = await fetch("/misapi/api/ordinary/province", {
-          headers: { Accept: "application/json" },
-        });
+        let url = "/misapi/api/ordinary/province";
+        if (locked["Region"]?.code) {
+          url += `?regionCode=${locked["Region"].code}`;
+        }
+        const res = await fetch(url, { headers: { Accept: "application/json" } });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
-        const provData = data.data || [];
-        setProvinces(provData);
+        setProvinces(data.data || []);
       } catch (err: unknown) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         setProvinceError(errorMsg || "Failed to load provinces");
@@ -88,7 +94,14 @@ const CustomersHighestOutstanding: React.FC = () => {
       }
     };
     fetchProvinces();
-  }, []);
+  }, [user.Level, user.RegionCode]);
+
+  useEffect(() => {
+    if (locked["Province"]) {
+      setScope("Province");
+      setSelectedCode(locked["Province"]!.code);
+    }
+  }, [scope, user.Level, user.ProvinceCode]);
 
   // Fetch Divisions (Regions)
   useEffect(() => {
@@ -115,6 +128,11 @@ const CustomersHighestOutstanding: React.FC = () => {
 
   // Sync selectedCode when scope changes or list loads
   useEffect(() => {
+    if (locked["Province"]) return; // handled by the forcing effect above
+    if (scope === "Division" && locked["Region"]) {
+      setSelectedCode(locked["Region"]!.code);
+      return;
+    }
     if (scope === "Province" && provinces.length > 0) {
       if (!selectedCode || !provinces.some((p) => p.ProvinceCode === selectedCode)) {
         setSelectedCode(provinces[0].ProvinceCode);
@@ -126,7 +144,7 @@ const CustomersHighestOutstanding: React.FC = () => {
     } else {
       setSelectedCode("");
     }
-  }, [scope, provinces, divisions, selectedCode]);
+  }, [scope, provinces, divisions, selectedCode, locked]);
 
   const handleViewReport = async () => {
     if (!selectedCode) {
@@ -246,7 +264,7 @@ const CustomersHighestOutstanding: React.FC = () => {
     rows.push(`Min Months in Arrears: ${monthsInArrears}`);
     rows.push(`Min Outstanding Balance: ${outstandingBalance}`);
     rows.push("");
-    
+
     if (scope === "Division") {
       rows.push("Province,Area Name,Account No,Name,Address,Telephone,Last Cash Date,Current Reading Date,Current Balance,kWh Charge,Current Balance - kWh Charge,Tariff,Months in Arrears,Units");
     } else {
@@ -295,7 +313,7 @@ const CustomersHighestOutstanding: React.FC = () => {
     const totalArrears = records.reduce((sum, r) => sum + (r.arrearsBalance ?? r.ArrearsBalance ?? 0), 0);
 
     return (
-      <tr 
+      <tr
         key={`total-${areaName}`}
         className="font-bold border-b border-gray-300"
         style={{ backgroundColor: "#E2F0D9" }}
@@ -334,7 +352,7 @@ const CustomersHighestOutstanding: React.FC = () => {
     const totalArrears = records.reduce((sum, r) => sum + (r.arrearsBalance ?? r.ArrearsBalance ?? 0), 0);
 
     return (
-      <tr 
+      <tr
         key="grand-total"
         className="font-bold border-b border-gray-300"
         style={{ backgroundColor: "#FFF2CC" }}
@@ -431,14 +449,14 @@ const CustomersHighestOutstanding: React.FC = () => {
           className="bg-white hover:bg-gray-50 text-gray-900 border-b border-gray-300"
         >
           {scope === "Division" && (
-            <td 
+            <td
               className="p-2 border border-gray-300 font-medium text-gray-700"
               style={{ borderBottom: isLastOfProvince ? undefined : "hidden" }}
             >
               {showProvince ? province : ""}
             </td>
           )}
-          <td 
+          <td
             className="p-2 border border-gray-300 font-medium text-gray-700"
             style={{ borderBottom: isLastOfArea ? undefined : "hidden" }}
           >
@@ -551,6 +569,17 @@ const CustomersHighestOutstanding: React.FC = () => {
     );
   };
 
+  if (user.Level === 50) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow-sm text-center">
+        <h2 className="text-lg font-bold text-[#7A0000] mb-2">Access Restricted</h2>
+        <p className="text-sm text-gray-600">
+          This report isn't available at your access level. Please contact your supervisor if you believe this is an error.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-7xl mx-auto p-4 bg-white rounded-xl shadow border border-gray-200 text-sm font-sans max-h-[82vh] overflow-y-auto">
       {!results && (
@@ -568,18 +597,25 @@ const CustomersHighestOutstanding: React.FC = () => {
           <div className="border border-gray-200 rounded-xl p-4 bg-white shadow mb-6">
             {/* Inputs Grid */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+
               {/* Scope Dropdown */}
               <div className="flex flex-col">
                 <label className={`${maroon} text-xs font-medium mb-1`}>Select Scope:</label>
-                <select
-                  value={scope}
-                  onChange={(e) => setScope(e.target.value as "Province" | "Division")}
-                  className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent bg-white text-gray-800"
-                  disabled={loading}
-                >
-                  <option value="Province">Province</option>
-                  <option value="Division">Division</option>
-                </select>
+                {locked["Province"] ? (
+                  <div className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-500 border-gray-200">
+                    Province
+                  </div>
+                ) : (
+                  <select
+                    value={scope}
+                    onChange={(e) => setScope(e.target.value as "Province" | "Division")}
+                    className="w-full px-2 py-1.5 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-[#7A0000] focus:border-transparent bg-white text-gray-800"
+                    disabled={loading}
+                  >
+                    <option value="Province">Province</option>
+                    <option value="Division">Division</option>
+                  </select>
+                )}
               </div>
 
               {/* Dropdown for Province or Division */}
@@ -588,7 +624,17 @@ const CustomersHighestOutstanding: React.FC = () => {
                   {scope === "Province" ? "Province" : "Division"}
                 </label>
                 {scope === "Province" ? (
-                  isLoadingProvinces ? (
+                  locked["Province"] ? (
+                    <select
+                      disabled
+                      value={locked["Province"]!.code}
+                      className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                    >
+                      <option value={locked["Province"]!.code}>
+                        {locked["Province"]!.name ? `${locked["Province"]!.code} - ${locked["Province"]!.name}` : locked["Province"]!.code}
+                      </option>
+                    </select>
+                  ) : isLoadingProvinces ? (
                     <div className="py-1 text-xs text-gray-500">Loading provinces...</div>
                   ) : provinceError ? (
                     <div className="text-red-600 text-xs py-1">{provinceError}</div>
@@ -607,6 +653,14 @@ const CustomersHighestOutstanding: React.FC = () => {
                       ))}
                     </select>
                   )
+                ) : locked["Region"] ? (
+                  <select
+                    disabled
+                    value={locked["Region"]!.code}
+                    className="w-full px-2 py-1.5 text-xs border rounded-md bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+                  >
+                    <option value={locked["Region"]!.code}>{locked["Region"]!.code}</option>
+                  </select>
                 ) : isLoadingDivisions ? (
                   <div className="py-1 text-xs text-gray-500">Loading divisions...</div>
                 ) : divisionError ? (
@@ -669,9 +723,8 @@ const CustomersHighestOutstanding: React.FC = () => {
               <button
                 onClick={handleViewReport}
                 disabled={loading}
-                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${
-                  loading ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
-                }`}
+                className={`px-6 py-2 rounded-md font-medium transition-opacity duration-300 shadow ${maroonGrad} text-white ${loading ? "opacity-70 cursor-not-allowed" : "hover:opacity-90"
+                  }`}
               >
                 {loading ? "Loading..." : "View Report"}
               </button>

--- a/src/mainTopics/Collections/ReceivablePosition.tsx
+++ b/src/mainTopics/Collections/ReceivablePosition.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { FaFileDownload, FaPrint } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { useReportScope } from "../../hooks/useReportScope";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -135,6 +137,9 @@ const ReceivablePosition: React.FC = () => {
   const [resolvedBillCycle, setResolvedBillCycle] = useState("");
   const [resolvedScopeLabel, setResolvedScopeLabel] = useState("");
 
+  const { user } = useUser();
+  const { locked } = useReportScope();
+
   // ── 1. Fetch bill cycles whenever billType changes ─────────────────────
   useEffect(() => {
     const fetchCycles = async () => {
@@ -176,9 +181,25 @@ const ReceivablePosition: React.FC = () => {
     fetchCycles();
   }, [billType]);
 
+  useEffect(() => {
+    if (locked["Area"]) {
+      setScopeType("Province");
+      setScopeValue(user.ProvinceCode || "");
+    } else if (locked["Province"]) {
+      setScopeType("Province");
+      setScopeValue(locked["Province"]!.code);
+    } else if (locked["Region"] && scopeType === "Region") {
+      setScopeValue(locked["Region"]!.code);
+    }
+  }, [scopeType, user.Level, user.RegionCode, user.ProvinceCode, user.AreaCode]);
+
   // ── 2. Fetch provinces + regions whenever billType changes ─────────────
   useEffect(() => {
-    const provUrl = billType === "B" ? `/misapi/api/bulk/province` : `/misapi/api/ordinary/province`;
+    const provUrl = (() => {
+      let url = billType === "B" ? `/misapi/api/bulk/province` : `/misapi/api/ordinary/province`;
+      if (locked["Region"]?.code) url += `?regionCode=${locked["Region"].code}`;
+      return url;
+    })();
     const regUrl = billType === "B" ? `/misapi/api/bulk/region` : `/misapi/api/ordinary/region`;
 
     setProvinces([]);
@@ -223,45 +244,51 @@ const ReceivablePosition: React.FC = () => {
         setScopeListError(errors.join(" "));
       }
     })();
-  }, [billType]);
+  }, [billType, user.Level, user.RegionCode]);
 
   // ── Reset scope value when scope type changes ───────────────────────────
   useEffect(() => {
+    if (locked["Area"] || locked["Province"] || locked["Region"]) return;
     setScopeValue("");
     setScopeListError(null);
   }, [scopeType, billType]);
 
   // ── 3. Resolve area list for the current scope + billType + scopeValue ─
   const resolveAreaList = useCallback(async (): Promise<AreaInfo[]> => {
+    let list: AreaInfo[];
+
     if (scopeType === "EntireCEB") {
       const url = billType === "B" ? `/misapi/api/bulk/areas` : `/misapi/api/ordinary/areas`;
       const res = await apiFetch<any[]>(url);
       if (res.errorMessage || !res.data) throw new Error(res.errorMessage || "Failed to load areas.");
-      return res.data.map((a: any) => ({
+      list = res.data.map((a: any) => ({
         areaCode: a.AreaCode ?? a.areaCode ?? "",
         areaName: a.AreaName ?? a.areaName ?? "",
       }));
-    }
-
-    if (scopeType === "Province") {
+    } else if (scopeType === "Province") {
       const url = `/misapi/api/receivable-position/areas-by-province?provinceCode=${encodeURIComponent(scopeValue)}&billType=${billType}`;
       const res = await apiFetch<any[]>(url);
       if (res.errorMessage || !res.data) throw new Error(res.errorMessage || "Failed to load areas for province.");
-      return res.data.map((a: any) => ({
+      list = res.data.map((a: any) => ({
+        areaCode: a.AreaCode ?? a.areaCode ?? "",
+        areaName: a.AreaName ?? a.areaName ?? "",
+      }));
+    } else {
+      const url = `/misapi/api/receivable-position/areas-by-region?regionCode=${encodeURIComponent(scopeValue)}&billType=${billType}`;
+      const res = await apiFetch<any[]>(url);
+      if (res.errorMessage || !res.data) throw new Error(res.errorMessage || "Failed to load areas for region.");
+      list = res.data.map((a: any) => ({
         areaCode: a.AreaCode ?? a.areaCode ?? "",
         areaName: a.AreaName ?? a.areaName ?? "",
       }));
     }
 
-    // Region
-    const url = `/misapi/api/receivable-position/areas-by-region?regionCode=${encodeURIComponent(scopeValue)}&billType=${billType}`;
-    const res = await apiFetch<any[]>(url);
-    if (res.errorMessage || !res.data) throw new Error(res.errorMessage || "Failed to load areas for region.");
-    return res.data.map((a: any) => ({
-      areaCode: a.AreaCode ?? a.areaCode ?? "",
-      areaName: a.AreaName ?? a.areaName ?? "",
-    }));
-  }, [scopeType, scopeValue, billType]);
+    if (locked["Area"]?.code) {
+      list = list.filter((a) => a.areaCode === locked["Area"]!.code);
+    }
+
+    return list;
+  }, [scopeType, scopeValue, billType, locked]);
 
   // ── 4. Fetch report: resolve areas, then loop report calls per area ────
   const fetchReport = useCallback(async () => {
@@ -519,9 +546,8 @@ const ReceivablePosition: React.FC = () => {
 </style>
 </head><body>
 <h2>${title}</h2>
-<div class="meta">Scope : &nbsp;<span>${resolvedScopeLabel}</span> (${scopeType}) &nbsp;|&nbsp; Customer Type : &nbsp;<span>${
-      billType === "B" ? "Bulk" : "Ordinary"
-    }</span><br>Bill Cycle : &nbsp;<span>${resolvedBillCycle}</span></div>
+<div class="meta">Scope : &nbsp;<span>${resolvedScopeLabel}</span> (${scopeType}) &nbsp;|&nbsp; Customer Type : &nbsp;<span>${billType === "B" ? "Bulk" : "Ordinary"
+      }</span><br>Bill Cycle : &nbsp;<span>${resolvedBillCycle}</span></div>
 <table><thead><tr>
   <th>Area</th><th>Area Name</th>
   <th>Opening Bal</th><th>Monthly Chg</th><th>Debits</th><th>Credits</th>
@@ -563,6 +589,18 @@ const ReceivablePosition: React.FC = () => {
 
   const canSubmit = !!selectedBillCycle && (scopeType === "EntireCEB" || !!scopeValue) && !loadingReport;
 
+
+  if (user.Level === 50) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow-sm text-center">
+        <h2 className="text-lg font-bold text-[#7A0000] mb-2">Access Restricted</h2>
+        <p className="text-sm text-gray-600">
+          This report isn't available at your access level. Please contact your supervisor if you believe this is an error.
+        </p>
+      </div>
+    );
+  }
+
   // ── Render ───────────────────────────────────────────────────────────────
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
@@ -601,47 +639,64 @@ const ReceivablePosition: React.FC = () => {
             </div>
 
             {/* Scope type */}
+            {/* Scope type */}
             <div className="flex flex-col">
               <label className={`text-xs font-medium mb-1 ${maroon}`}>Select Category:</label>
-              <select value={scopeType} onChange={(e) => setScopeType(e.target.value as ScopeType)} className={selectCls}>
-                <option value="Province">Province</option>
-                <option value="Region">Region</option>
-                <option value="EntireCEB">Entire CEB</option>
-              </select>
+              {locked["Area"] ? (
+                <div className={disabledSelectCls}>
+                  {user.AreaName ? `${user.AreaCode} - ${user.AreaName}` : user.AreaCode}
+                </div>
+              ) : (
+                <select value={scopeType} onChange={(e) => setScopeType(e.target.value as ScopeType)} className={selectCls}>
+                  {!locked["Region"] && !locked["Province"] && <option value="EntireCEB">Entire CEB</option>}
+                  {!locked["Province"] && <option value="Region">Region</option>}
+                  <option value="Province">Province</option>
+                </select>
+              )}
             </div>
 
             {/* Scope value */}
-            {scopeType !== "EntireCEB" && (
+            {!locked["Area"] && scopeType !== "EntireCEB" && (
               <div className="flex flex-col">
                 <label className={`text-xs font-medium mb-1 ${maroon}`}>
                   Select {scopeType === "Province" ? "Province" : "Region"}:
                 </label>
 
                 {scopeType === "Province" && (
-                  <select value={scopeValue} onChange={(e) => setScopeValue(e.target.value)} className={selectCls}>
-                    <option value="">Select Province</option>
-                    {provinces.map((p) => (
-                      <option key={p.provinceCode} value={p.provinceCode}>
-                        {p.provinceName}
-                      </option>
-                    ))}
-                  </select>
+                  locked["Province"] ? (
+                    <div className={disabledSelectCls}>
+                      {locked["Province"]!.name ? `${locked["Province"]!.code} - ${locked["Province"]!.name}` : locked["Province"]!.code}
+                    </div>
+                  ) : (
+                    <select value={scopeValue} onChange={(e) => setScopeValue(e.target.value)} className={selectCls}>
+                      <option value="">Select Province</option>
+                      {provinces.map((p) => (
+                        <option key={p.provinceCode} value={p.provinceCode}>
+                          {p.provinceName}
+                        </option>
+                      ))}
+                    </select>
+                  )
                 )}
 
                 {scopeType === "Region" && (
-                  <select value={scopeValue} onChange={(e) => setScopeValue(e.target.value)} className={selectCls}>
-                    <option value="">Select Region</option>
-                    {regions.map((r) => (
-                      <option key={r.regionCode} value={r.regionCode}>
-                        {r.regionName || r.regionCode}
-                      </option>
-                    ))}
-                  </select>
+                  locked["Region"] ? (
+                    <div className={disabledSelectCls}>{locked["Region"]!.code}</div>
+                  ) : (
+                    <select value={scopeValue} onChange={(e) => setScopeValue(e.target.value)} className={selectCls}>
+                      <option value="">Select Region</option>
+                      {regions.map((r) => (
+                        <option key={r.regionCode} value={r.regionCode}>
+                          {r.regionName || r.regionCode}
+                        </option>
+                      ))}
+                    </select>
+                  )
                 )}
               </div>
             )}
 
-            {scopeType === "EntireCEB" && (
+            {!locked["Area"] && scopeType === "EntireCEB" && (
               <div className="flex flex-col">
                 <label className={`text-xs font-medium mb-1 text-gray-400`}>Select Area:</label>
                 <div className={disabledSelectCls}>All areas island-wide</div>

--- a/src/routes/ReportRoutes.tsx
+++ b/src/routes/ReportRoutes.tsx
@@ -154,7 +154,7 @@ const ReportRoutes = () => (
 		/>
 
 		<Route
-			path="/report/LedgerCards"
+			path="/report/ledger-card"
 			element={
 				<Layout>
 					<LedgerCardDetails />


### PR DESCRIPTION
## Summary
Adds level-based access control to two Collections reports so users only see and query data within the scope authorized for their user level.

- `CustomersHighestOutstanding.tsx`
- `ReceivablePosition.tsx`

## Details
- Integrated the `useReportScope` hook to determine each user's locked scope (`Chairman` / `Region` / `Province` / `Area`) based on `user.Level`.
- Scope selectors (Province/Division/Area) are now auto-set and locked when a user's level restricts them to a specific Region, Province, or Area — preventing manual selection outside their authorized scope.
- Data fetches (provinces, divisions/regions, areas) are filtered/scoped using the locked value (e.g. provinces are fetched with `regionCode` when a Region is locked; areas are filtered by locked `Area` code).
- Unrestricted users (e.g. Chairman level) retain full access to select Entire CEB / Region / Province / Area as before.
- No changes to report calculation logic, CSV export, or print/PDF functionality — access control is applied only at the scope-selection and data-fetch layer.

## Scope levels
| Level | Access |
|---|---|
| Chairman / 80 | Full access — Entire CEB / Region / Province / Area |
| Region | Locked to assigned Region; can drill into Provinces/Areas within it |
| Province | Locked to assigned Province |
| Area | Locked to assigned Area |

## Testing
- [x] Verified each user level sees only their authorized scope on report load
- [x] Verified locked scope values are correctly pre-filled and disabled in the UI
- [x] Verified report data returned matches the locked scope
- [x] Verified Chairman-level access is unaffected (no restriction)
- [x] Verified CSV export and Print/PDF still work correctly per scope

## Files changed
- `src/.../CustomersHighestOutstanding.tsx`
- `src/.../ReceivablePosition.tsx`