### PR TITLE
Restrict SolarCustomerInformation account lookup to the user's assigned scope

### DIFF
--- a/src/hooks/useReportScope.ts
+++ b/src/hooks/useReportScope.ts
@@ -25,3 +25,16 @@ export function useReportScope() {
 
   return { level, allowedCategories, locked };
 }
+
+export function isWithinUserScope(
+  user: { Level?: number; RegionCode?: string; ProvinceCode?: string; AreaCode?: string },
+  recordArea?: string,
+  recordProvince?: string,
+  recordRegion?: string
+): boolean {
+  const level = user.Level ?? 80;
+  if (level >= 80) return true;
+  if (level >= 70) return recordRegion === user.RegionCode;
+  if (level >= 60) return recordProvince === user.ProvinceCode;
+  return recordArea === user.AreaCode;
+}

--- a/src/mainTopics/SolarInformation/SolarCustomerInformation.tsx
+++ b/src/mainTopics/SolarInformation/SolarCustomerInformation.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef } from "react";
 import { FaFileDownload, FaPrint, FaTimes } from "react-icons/fa";
+import { useUser } from "../../contexts/UserContext";
+import { isWithinUserScope } from "../../hooks/useReportScope";
 
 interface CustomerInfo {
     AreaCode: string;
@@ -57,6 +59,7 @@ const SolarCustomerInformation: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const [customerData, setCustomerData] = useState<CustomerInformationResponse | null>(null);
     const [reportVisible, setReportVisible] = useState(false);
+    const { user } = useUser();
 
     const printRef = useRef<HTMLDivElement>(null);
 
@@ -149,6 +152,15 @@ const SolarCustomerInformation: React.FC = () => {
             }
 
             if (result.data) {
+                const info = result.data.CustomerInfo;
+
+                if (!isWithinUserScope(user, info?.AreaCode, info?.ProvinceCode, info?.Region)) {
+                    setError("This account is outside your access scope.");
+                    setCustomerData(null);
+                    setReportVisible(false);
+                    return;
+                }
+
                 setCustomerData(result.data);
                 setReportVisible(true);
             } else {


### PR DESCRIPTION
## What this does

`SolarCustomerInformation` is an account-number lookup report with no Area/Province/Region dropdown to restrict — previously, any logged-in user could search for and view any account number's full solar customer details, regardless of their assigned level or location.

This adds a scope check after the lookup resolves: if the returned account's area/province/region doesn't fall within the logged-in user's assigned scope, the details are not shown and an "outside your access scope" message is displayed instead.

## Access rules

| Level | Can view accounts in |
|---|---|
| 80 (Chairman) | Any account, anywhere |
| 70 (Region) | Only accounts within their own region |
| 60 (Province) | Only accounts within their own province |
| 50 (Area) | Only accounts within their own area |

## Implementation

Added a new reusable helper, `isWithinUserScope()`, to `useReportScope.ts` — purely additive, appended alongside the existing `useReportScope` hook without modifying it, so no report already using the hook is affected.

```ts
export function isWithinUserScope(
  user: { Level?: number; RegionCode?: string; ProvinceCode?: string; AreaCode?: string },
  recordArea?: string,
  recordProvince?: string,
  recordRegion?: string
): boolean { ... }
```

`SolarCustomerInformation.tsx` now calls this after a successful lookup:
```tsx
if (!isWithinUserScope(user, info?.AreaCode, info?.ProvinceCode, info?.Region)) {
  setError("This account is outside your access scope.");
  setCustomerData(null);
  setReportVisible(false);
  return;
}
```

This is intentionally the same trust model used across the rest of the application — the check happens client-side, consistent with every other report's access restriction so far.

## Testing done

Verified with the 5 real EPF test accounts:
- Chairman: can look up any account
- Region/Province/Area-level users: correctly blocked with the new message when searching for an account outside their scope, and correctly succeed for accounts within it