### PR TITLE
Improve cost centre ID normalization

### DIFF
--- a/src/mainTopics/Admin/RepRoles/userroles.tsx
+++ b/src/mainTopics/Admin/RepRoles/userroles.tsx
@@ -146,8 +146,10 @@ const resolveAssignedCompanyIds = (
 		}));
 };
 
-const normalizeCostCentreId = (value: unknown): string =>
-	normalizeText(value).split("-")[0].trim();
+const normalizeCostCentreId = (value: unknown): string => {
+	const text = normalizeText(value);
+	return text.includes(" - ") ? text.split(" - ")[0].trim() : text;
+};
 
 const uniqueCostCentreIds = (values: string[]): string[] =>
 	uniqueByNormalizedKey(values.map(normalizeCostCentreId).filter(Boolean));


### PR DESCRIPTION
Make normalizeCostCentreId split only on the explicit " - " delimiter and return the full normalized text if no delimiter is present. This prevents incorrect splitting on stray hyphens and preserves cost centre IDs that don't use the spaced hyphen separator. Minor refactor for clarity in src/mainTopics/Admin/RepRoles/userroles.tsx.